### PR TITLE
ci: enforce semver

### DIFF
--- a/.github/workflows/on-push.yaml
+++ b/.github/workflows/on-push.yaml
@@ -18,6 +18,7 @@ jobs:
       - tests
       - integration-tests
       - test-windows
+      - semver
     steps:
       - run: exit 0
 
@@ -97,3 +98,9 @@ jobs:
         with:
           toolchain: stable
       - run: cargo test -- --ignored
+
+  semver:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: obi1kenobi/cargo-semver-checks-action@v2


### PR DESCRIPTION
One of the goals in maintaining this fork is that it will always be a drop-in replacements for the upstream `boringtun` via `[patch.crates-io]`. As such, not making any semver breaking changes is crucial.