### PR TITLE
chore: lower log-levels for timeouts to `debug`

### DIFF
--- a/boringtun/src/noise/timers.rs
+++ b/boringtun/src/noise/timers.rs
@@ -203,7 +203,7 @@ impl Tunn {
             // All ephemeral private keys and symmetric session keys are zeroed out after
             // (REJECT_AFTER_TIME * 3) ms if no new keys have been exchanged.
             if now - session_established >= REJECT_AFTER_TIME * 3 {
-                tracing::error!("CONNECTION_EXPIRED(REJECT_AFTER_TIME * 3)");
+                tracing::debug!("CONNECTION_EXPIRED(REJECT_AFTER_TIME * 3)");
                 self.handshake.set_expired();
                 self.clear_all();
                 return TunnResult::Err(WireGuardError::ConnectionExpired);
@@ -216,7 +216,7 @@ impl Tunn {
                     // the retries give up and cease, and clear all existing packets queued
                     // up to be sent. If a packet is explicitly queued up to be sent, then
                     // this timer is reset.
-                    tracing::error!("CONNECTION_EXPIRED(REKEY_ATTEMPT_TIME)");
+                    tracing::debug!("CONNECTION_EXPIRED(REKEY_ATTEMPT_TIME)");
                     self.handshake.set_expired();
                     self.clear_all();
                     return TunnResult::Err(WireGuardError::ConnectionExpired);
@@ -228,7 +228,7 @@ impl Tunn {
                     // A handshake initiation is retried after REKEY_TIMEOUT + jitter ms,
                     // if a response has not been received, where jitter is some random
                     // value between 0 and 333 ms.
-                    tracing::warn!("HANDSHAKE(REKEY_TIMEOUT)");
+                    tracing::debug!("HANDSHAKE(REKEY_TIMEOUT)");
                     handshake_initiation_required = true;
                 }
             } else {
@@ -253,7 +253,7 @@ impl Tunn {
                         && now - session_established
                             >= REJECT_AFTER_TIME - KEEPALIVE_TIMEOUT - REKEY_TIMEOUT
                     {
-                        tracing::warn!(
+                        tracing::debug!(
                             "HANDSHAKE(REJECT_AFTER_TIME - KEEPALIVE_TIMEOUT - \
                         REKEY_TIMEOUT \
                         (on receive))"
@@ -269,7 +269,7 @@ impl Tunn {
                     && now - aut_packet_received >= KEEPALIVE_TIMEOUT + REKEY_TIMEOUT
                     && mem::replace(&mut self.timers.want_handshake, false)
                 {
-                    tracing::warn!("HANDSHAKE(KEEPALIVE + REKEY_TIMEOUT)");
+                    tracing::debug!("HANDSHAKE(KEEPALIVE + REKEY_TIMEOUT)");
                     handshake_initiation_required = true;
                 }
 


### PR DESCRIPTION
In an application that mostly uses ephemeral WireGuard tunnels, endpoints might roam away at any point which results in the other side running into a timeout. In that case, connections expiring might happen during normal operation, so logging these on WARN or ERROR is too noisy.