### PR TITLE
fix: don't send keep-alives as responder without session

### DIFF
--- a/boringtun/src/noise/mod.rs
+++ b/boringtun/src/noise/mod.rs
@@ -692,7 +692,7 @@ mod tests {
     use super::*;
     use rand_core::{OsRng, RngCore};
 
-    fn create_two_tuns(now: Instant) -> (Tunn, Tunn) {
+    fn create_two_tuns(now: Instant, keep_alive: Option<u16>) -> (Tunn, Tunn) {
         let my_secret_key = x25519_dalek::StaticSecret::random_from_rng(OsRng);
         let my_public_key = x25519_dalek::PublicKey::from(&my_secret_key);
         let my_idx = OsRng.next_u32();
@@ -705,7 +705,7 @@ mod tests {
             my_secret_key,
             their_public_key,
             None,
-            None,
+            keep_alive,
             my_idx,
             None,
             now,
@@ -715,7 +715,7 @@ mod tests {
             their_secret_key,
             my_public_key,
             None,
-            None,
+            keep_alive,
             their_idx,
             None,
             now,
@@ -771,8 +771,8 @@ mod tests {
         assert!(matches!(keepalive, TunnResult::Done));
     }
 
-    fn create_two_tuns_and_handshake(now: Instant) -> (Tunn, Tunn) {
-        let (mut my_tun, mut their_tun) = create_two_tuns(now);
+    fn create_two_tuns_and_handshake(now: Instant, keep_alive: Option<u16>) -> (Tunn, Tunn) {
+        let (mut my_tun, mut their_tun) = create_two_tuns(now, keep_alive);
         let init = create_handshake_init(&mut my_tun, now);
         let resp = create_handshake_response(&mut their_tun, &init, now);
         let keepalive = parse_handshake_resp(&mut my_tun, &resp, now);
@@ -807,14 +807,14 @@ mod tests {
     fn create_two_tunnels_linked_to_eachother() {
         let now = Instant::now();
 
-        let (_my_tun, _their_tun) = create_two_tuns(now);
+        let (_my_tun, _their_tun) = create_two_tuns(now, None);
     }
 
     #[test]
     fn handshake_init() {
         let now = Instant::now();
 
-        let (mut my_tun, _their_tun) = create_two_tuns(now);
+        let (mut my_tun, _their_tun) = create_two_tuns(now, None);
         let init = create_handshake_init(&mut my_tun, now);
         let packet = Tunn::parse_incoming_packet(&init).unwrap();
         assert!(matches!(packet, Packet::HandshakeInit(_)));
@@ -824,7 +824,7 @@ mod tests {
     fn handshake_init_and_response() {
         let now = Instant::now();
 
-        let (mut my_tun, mut their_tun) = create_two_tuns(now);
+        let (mut my_tun, mut their_tun) = create_two_tuns(now, None);
         let init = create_handshake_init(&mut my_tun, now);
         let resp = create_handshake_response(&mut their_tun, &init, now);
         let packet = Tunn::parse_incoming_packet(&resp).unwrap();
@@ -835,7 +835,7 @@ mod tests {
     fn full_handshake() {
         let now = Instant::now();
 
-        let (mut my_tun, mut their_tun) = create_two_tuns(now);
+        let (mut my_tun, mut their_tun) = create_two_tuns(now, None);
         let init = create_handshake_init(&mut my_tun, now);
         let resp = create_handshake_response(&mut their_tun, &init, now);
         let keepalive = parse_handshake_resp(&mut my_tun, &resp, now);
@@ -847,7 +847,7 @@ mod tests {
     fn full_handshake_plus_timers() {
         let now = Instant::now();
 
-        let (mut my_tun, mut their_tun) = create_two_tuns_and_handshake(now);
+        let (mut my_tun, mut their_tun) = create_two_tuns_and_handshake(now, None);
         // Time has not yet advanced so their is nothing to do
         assert!(matches!(
             my_tun.update_timers_at(&mut [], now),
@@ -863,7 +863,7 @@ mod tests {
     fn new_handshake_after_two_mins() {
         let mut now = Instant::now();
 
-        let (mut my_tun, mut their_tun) = create_two_tuns_and_handshake(now);
+        let (mut my_tun, mut their_tun) = create_two_tuns_and_handshake(now, None);
         let mut my_dst = [0u8; 1024];
 
         // Advance time 1 second and "send" 1 packet so that we send a handshake
@@ -897,7 +897,7 @@ mod tests {
     fn handshake_no_resp_rekey_timeout() {
         let mut now = Instant::now();
 
-        let (mut my_tun, _their_tun) = create_two_tuns(now);
+        let (mut my_tun, _their_tun) = create_two_tuns(now, None);
 
         let init = create_handshake_init(&mut my_tun, now);
         let packet = Tunn::parse_incoming_packet(&init).unwrap();
@@ -909,7 +909,7 @@ mod tests {
 
     #[test]
     fn one_ip_packet() {
-        let (mut my_tun, mut their_tun) = create_two_tuns_and_handshake(Instant::now());
+        let (mut my_tun, mut their_tun) = create_two_tuns_and_handshake(Instant::now(), None);
         let mut my_dst = [0u8; 1024];
         let mut their_dst = [0u8; 1024];
 

--- a/boringtun/src/noise/timers.rs
+++ b/boringtun/src/noise/timers.rs
@@ -11,7 +11,7 @@ use std::time::{Duration, Instant};
 // Some constants, represent time in seconds
 // https://www.wireguard.com/papers/wireguard.pdf#page=14
 pub(crate) const REKEY_AFTER_TIME: Duration = Duration::from_secs(120);
-const REJECT_AFTER_TIME: Duration = Duration::from_secs(180);
+pub(crate) const REJECT_AFTER_TIME: Duration = Duration::from_secs(180);
 const REKEY_ATTEMPT_TIME: Duration = Duration::from_secs(90);
 pub(crate) const REKEY_TIMEOUT: Duration = Duration::from_secs(5);
 const KEEPALIVE_TIMEOUT: Duration = Duration::from_secs(10);
@@ -301,7 +301,7 @@ impl Tunn {
             return self.format_handshake_initiation_at(dst, true, time);
         }
 
-        if keepalive_required {
+        if keepalive_required && (self.has_current_session() || self.timers.is_initiator) {
             return self.encapsulate_at(&[], dst, time);
         }
 


### PR DESCRIPTION
In WireGuard, sessions expire after 180s. In case data has been sent through the tunnel already, WireGuard will initiate a re-key after 120s. Otherwise, the tunnel will expire. Here is the catch: If both sides have a persistent keep-alive configured, attempting to send the next keep-alive with an expired tunnel will initiate a new handshake. This results in both parties sending handshake initiations to each other, effectively fighting over being the initiator of the new handshake. Here are some logs from a test run that demonstrates this:

```
 73.680s DEBUG client: boringtun::noise::timers: KEEPALIVE(PERSISTENT_KEEPALIVE)
 73.680s DEBUG server: boringtun::noise::timers: KEEPALIVE(PERSISTENT_KEEPALIVE)
102.750s DEBUG client: boringtun::noise::timers: KEEPALIVE(PERSISTENT_KEEPALIVE)
102.750s DEBUG server: boringtun::noise::timers: KEEPALIVE(PERSISTENT_KEEPALIVE)
130.900s DEBUG client: boringtun::noise::timers: KEEPALIVE(PERSISTENT_KEEPALIVE)
130.900s DEBUG server: boringtun::noise::timers: KEEPALIVE(PERSISTENT_KEEPALIVE)
159.970s DEBUG client: boringtun::noise::timers: KEEPALIVE(PERSISTENT_KEEPALIVE)
159.970s DEBUG server: boringtun::noise::timers: KEEPALIVE(PERSISTENT_KEEPALIVE)
188.080s DEBUG client: boringtun::noise::timers: KEEPALIVE(PERSISTENT_KEEPALIVE)
188.080s DEBUG server: boringtun::noise::timers: KEEPALIVE(PERSISTENT_KEEPALIVE)
217.150s DEBUG client: boringtun::noise::timers: KEEPALIVE(PERSISTENT_KEEPALIVE)
217.150s DEBUG server: boringtun::noise::timers: KEEPALIVE(PERSISTENT_KEEPALIVE)
231.220s DEBUG client: boringtun::noise::timers: SESSION_EXPIRED(REJECT_AFTER_TIME) session=1941345281
231.220s DEBUG server: boringtun::noise::timers: SESSION_EXPIRED(REJECT_AFTER_TIME) session=1507565313
246.220s DEBUG client: boringtun::noise::timers: KEEPALIVE(PERSISTENT_KEEPALIVE)
246.220s DEBUG client: boringtun::noise: Sending handshake_initiation
246.220s DEBUG server: boringtun::noise::timers: KEEPALIVE(PERSISTENT_KEEPALIVE)
246.220s DEBUG server: boringtun::noise: Sending handshake_initiation
246.490s DEBUG client: boringtun::noise: Received handshake_initiation remote_idx=1507565314
246.490s DEBUG client: boringtun::noise: Sending handshake_response local_idx=1941345283
246.490s DEBUG client: boringtun::noise: Sending handshake_initiation
246.490s DEBUG server: boringtun::noise: Received handshake_initiation remote_idx=1941345282
246.490s DEBUG server: boringtun::noise: Sending handshake_response local_idx=1507565315
246.490s DEBUG server: boringtun::noise: Sending handshake_initiation
246.760s DEBUG client: boringtun::noise: Received handshake_initiation remote_idx=1507565316
246.760s DEBUG client: boringtun::noise: Sending handshake_response local_idx=1941345285
246.760s DEBUG client: boringtun::noise: Sending handshake_initiation
246.760s DEBUG client: boringtun::noise: Received handshake_response local_idx=1941345282 remote_idx=1507565315
246.760s DEBUG client: Failed to decapsulate incoming packet error=Failed to decapsulate: UnexpectedPacket local=[2001:db80::]:6526 num_bytes=92
246.760s DEBUG server: boringtun::noise: Received handshake_initiation remote_idx=1941345284
246.760s DEBUG server: boringtun::noise: Sending handshake_response local_idx=1507565317
246.760s DEBUG server: boringtun::noise: Sending handshake_initiation
246.760s DEBUG server: boringtun::noise: Received handshake_response local_idx=1507565314 remote_idx=1941345283
246.760s DEBUG server: Failed to decapsulate incoming packet error=Failed to decapsulate: UnexpectedPacket from=[2001:db80::]:6526 num_bytes=92
247.030s DEBUG client: boringtun::noise: Received handshake_initiation remote_idx=1507565318
247.030s DEBUG client: boringtun::noise: Sending handshake_response local_idx=1941345287
247.030s DEBUG client: boringtun::noise: Sending handshake_initiation
247.030s DEBUG client: boringtun::noise: Received handshake_response local_idx=1941345284 remote_idx=1507565317
247.030s DEBUG client: Failed to decapsulate incoming packet error=Failed to decapsulate: UnexpectedPacket local=[2001:db80::]:6526 num_bytes=92
247.030s DEBUG server: boringtun::noise: Received handshake_initiation remote_idx=1941345286
247.030s DEBUG server: boringtun::noise: Sending handshake_response local_idx=1507565319
247.030s DEBUG server: boringtun::noise: Sending handshake_initiation
247.030s DEBUG server: boringtun::noise: Received handshake_response local_idx=1507565316 remote_idx=1941345285
247.030s DEBUG server: Failed to decapsulate incoming packet error=Failed to decapsulate: UnexpectedPacket from=[2001:db80::]:6526 num_bytes=92
247.300s DEBUG client: boringtun::noise: Received handshake_initiation remote_idx=1507565320
247.300s DEBUG client: boringtun::noise: Sending handshake_response local_idx=1941345289
247.300s DEBUG client: boringtun::noise: Received handshake_response local_idx=1941345286 remote_idx=1507565319
247.300s DEBUG client: Failed to decapsulate incoming packet error=Failed to decapsulate: UnexpectedPacket local=[2001:db80::]:6526 num_bytes=92
247.300s DEBUG server: boringtun::noise: Received handshake_initiation remote_idx=1941345288
247.300s DEBUG server: boringtun::noise: Sending handshake_response local_idx=1507565321
247.300s DEBUG server: boringtun::noise: Received handshake_response local_idx=1507565318 remote_idx=1941345287
247.300s DEBUG server: Failed to decapsulate incoming packet error=Failed to decapsulate: UnexpectedPacket from=[2001:db80::]:6526 num_bytes=92
247.570s DEBUG client: boringtun::noise: Received handshake_response local_idx=1941345288 remote_idx=1507565321
247.570s DEBUG client: boringtun::noise: New session session=1941345288
247.570s DEBUG client: boringtun::noise: Sending keepalive
247.570s DEBUG server: boringtun::noise: Received handshake_response local_idx=1507565320 remote_idx=1941345289
247.570s DEBUG server: boringtun::noise: New session session=1507565320
247.570s DEBUG server: boringtun::noise: Sending keepalive
```

We can mitigate this by adding an additional condition to the `keepalive_required` condition:

- Either we must have an active session
- Or we were the initiator of the previous handshake