### PR TITLE
fix: remove panics from packet processing path

### DIFF
--- a/boringtun/src/noise/mod.rs
+++ b/boringtun/src/noise/mod.rs
@@ -251,7 +251,10 @@ impl Tunn {
         let current = self.current;
         if let Some(ref session) = self.sessions[current % N_SESSIONS] {
             // Send the packet using an established session
-            let packet = session.format_packet_data(src, dst);
+            let packet = match session.format_packet_data(src, dst) {
+                Ok(p) => p,
+                Err(e) => return TunnResult::Err(e),
+            };
             self.timer_tick(TimerName::TimeLastPacketSent);
             // Exclude Keepalive packets from timer update.
             if !src.is_empty() {
@@ -353,7 +356,7 @@ impl Tunn {
 
         let session = self.handshake.receive_handshake_response(p)?;
 
-        let keepalive_packet = session.format_packet_data(&[], dst);
+        let keepalive_packet = session.format_packet_data(&[], dst)?;
         // Store new session in ring buffer
         let l_idx = session.local_index();
         let index = l_idx % N_SESSIONS;


### PR DESCRIPTION
At present, there are several `panic!`s lurking in the processing path when the destination buffer for a particular packet isn't big enough. Whilst in theory this shouldn't happen, panicking and bringing the entire application down is not very good either. To give the application on top a better chance of recovering from this error, we replace the panic with an error.