### PR TITLE
chore: add warning logs when destination buffer is too small

### DIFF
--- a/boringtun/src/noise/handshake.rs
+++ b/boringtun/src/noise/handshake.rs
@@ -710,7 +710,10 @@ impl Handshake {
         &mut self,
         dst: &'a mut [u8],
     ) -> Result<&'a mut [u8], WireGuardError> {
-        if dst.len() < super::HANDSHAKE_INIT_SZ {
+        let buf_len = dst.len();
+        if buf_len < super::HANDSHAKE_INIT_SZ {
+            tracing::warn!(%buf_len, msg_len = %super::HANDSHAKE_INIT_SZ, "Destination buffer too small for handshake init message");
+
             return Err(WireGuardError::DestinationBufferTooSmall);
         }
 
@@ -790,7 +793,10 @@ impl Handshake {
         &mut self,
         dst: &'a mut [u8],
     ) -> Result<(&'a mut [u8], Session), WireGuardError> {
+        let buf_len = dst.len();
         if dst.len() < super::HANDSHAKE_RESP_SZ {
+            tracing::warn!(%buf_len, msg_len = %super::HANDSHAKE_RESP_SZ, "Destination buffer too small for handshake init message");
+
             return Err(WireGuardError::DestinationBufferTooSmall);
         }
 

--- a/boringtun/src/noise/rate_limiter.rs
+++ b/boringtun/src/noise/rate_limiter.rs
@@ -120,7 +120,10 @@ impl RateLimiter {
         mac1: &[u8],
         dst: &'a mut [u8],
     ) -> Result<&'a mut [u8], WireGuardError> {
-        if dst.len() < super::COOKIE_REPLY_SZ {
+        let buf_len = dst.len();
+        if buf_len < super::COOKIE_REPLY_SZ {
+            tracing::warn!(%buf_len, msg_len = %super::COOKIE_REPLY_SZ, "Destination buffer too small for cookie reply");
+
             return Err(WireGuardError::DestinationBufferTooSmall);
         }
 

--- a/boringtun/src/noise/session.rs
+++ b/boringtun/src/noise/session.rs
@@ -198,7 +198,12 @@ impl Session {
         src: &[u8],
         dst: &'a mut [u8],
     ) -> Result<&'a mut [u8], WireGuardError> {
-        if dst.len() < src.len() + super::DATA_OVERHEAD_SZ {
+        let buf_len = dst.len();
+        let num_required = src.len() + super::DATA_OVERHEAD_SZ;
+
+        if buf_len < num_required {
+            tracing::warn!(%buf_len, %num_required, "Destination buffer too small for outgoing packet data");
+
             return Err(WireGuardError::DestinationBufferTooSmall);
         }
 
@@ -243,7 +248,11 @@ impl Session {
         dst: &'a mut [u8],
     ) -> Result<&'a mut [u8], WireGuardError> {
         let ct_len = packet.encrypted_encapsulated_packet.len();
-        if dst.len() < ct_len {
+        let buf_len = dst.len();
+
+        if buf_len < ct_len {
+            tracing::warn!(%buf_len, %ct_len, "Destination buffer too small for incoming packet data");
+
             return Err(WireGuardError::DestinationBufferTooSmall);
         }
         if packet.receiver_idx != self.receiving_index {


### PR DESCRIPTION
Instead of just returning an error, we also add `tracing::warn` logs to describe the specific mismatch in buffer length. Normally, returning and logging an error is considered an anti-pattern. But, adding fields to the `DestinationBufferTooSmall` variant would be a breaking change and we want to stay semver-compatible for now. See https://github.com/firezone/boringtun?tab=readme-ov-file#how-to-use-this-fork.