### PR TITLE
fix: avoid spurious rekeying

### DIFF
--- a/boringtun/src/noise/timers.rs
+++ b/boringtun/src/noise/timers.rs
@@ -131,7 +131,11 @@ impl Tunn {
         }
 
         let time = self.timers[TimeCurrent];
-        self.timers[timer_name] = time;
+        if time.is_zero() {
+            self.timers[timer_name] = Duration::from_millis(1);
+        } else {
+            self.timers[timer_name] = time;
+        }
     }
 
     pub(super) fn timer_tick_session_established(

--- a/boringtun/src/noise/timers.rs
+++ b/boringtun/src/noise/timers.rs
@@ -55,8 +55,8 @@ pub struct Timers {
     pub(super) session_timers: [Duration; super::N_SESSIONS],
     /// Did we receive data without sending anything back?
     want_keepalive: bool,
-    /// Did we send data without hearing back?
-    want_handshake: bool,
+    /// How long ago did we send data without hearing back?
+    want_handshake_since: Option<Duration>,
     persistent_keepalive: usize,
     /// Should this timer call reset rr function (if not a shared rr instance)
     pub(super) should_reset_rr: bool,
@@ -79,7 +79,7 @@ impl Timers {
             timers: Default::default(),
             session_timers: Default::default(),
             want_keepalive: Default::default(),
-            want_handshake: Default::default(),
+            want_handshake_since: Default::default(),
             persistent_keepalive: usize::from(persistent_keepalive.unwrap_or(0)),
             should_reset_rr: reset_rr,
             send_handshake_at: None,
@@ -98,7 +98,7 @@ impl Timers {
         for t in &mut self.timers[..] {
             *t = now;
         }
-        self.want_handshake = false;
+        self.want_handshake_since = None;
         self.want_keepalive = false;
     }
 }
@@ -118,19 +118,21 @@ impl IndexMut<TimerName> for Timers {
 
 impl Tunn {
     pub(super) fn timer_tick(&mut self, timer_name: TimerName) {
+        let time = self.timers[TimeCurrent];
         match timer_name {
             TimeLastPacketReceived => {
                 self.timers.want_keepalive = true;
-                self.timers.want_handshake = false;
+                self.timers.want_handshake_since = None;
             }
             TimeLastPacketSent => {
-                self.timers.want_handshake = true;
                 self.timers.want_keepalive = false;
+            }
+            TimeLastDataPacketSent => {
+                self.timers.want_handshake_since.get_or_insert(time);
             }
             _ => {}
         }
 
-        let time = self.timers[TimeCurrent];
         if time.is_zero() {
             self.timers[timer_name] = Duration::from_millis(1);
         } else {
@@ -205,7 +207,6 @@ impl Tunn {
         // Load timers only once:
         let session_established = self.timers[TimeSessionEstablished];
         let handshake_started = self.timers[TimeLastHandshakeStarted];
-        let aut_packet_received = self.timers[TimeLastPacketReceived];
         let aut_packet_sent = self.timers[TimeLastPacketSent];
         let data_packet_received = self.timers[TimeLastDataPacketReceived];
         let data_packet_sent = self.timers[TimeLastDataPacketSent];
@@ -285,15 +286,20 @@ impl Tunn {
                     }
                 }
 
-                // If we have sent a packet to a given peer but have not received a
+                // If we have sent a data packet to a given peer but have not received a
                 // packet after from that peer for (KEEPALIVE + REKEY_TIMEOUT) ms,
                 // we initiate a new handshake.
-                if data_packet_sent > aut_packet_received
-                    && now - aut_packet_received >= KEEPALIVE_TIMEOUT + REKEY_TIMEOUT
-                    && mem::replace(&mut self.timers.want_handshake, false)
+                if self
+                    .timers
+                    .want_handshake_since
+                    .map(|want_handshake_since| {
+                        (now - want_handshake_since) >= (KEEPALIVE_TIMEOUT + REKEY_TIMEOUT)
+                    })
+                    .unwrap_or_default()
                 {
                     tracing::debug!("HANDSHAKE(KEEPALIVE + REKEY_TIMEOUT)");
                     handshake_initiation_required = true;
+                    self.timers.want_handshake_since = None;
                 }
 
                 if !handshake_initiation_required {

--- a/boringtun/src/noise/timers.rs
+++ b/boringtun/src/noise/timers.rs
@@ -123,6 +123,8 @@ impl Tunn {
             TimeLastPacketReceived => {
                 self.timers.want_keepalive = true;
                 self.timers.want_handshake_since = None;
+                // This timer is never read
+                return;
             }
             TimeLastPacketSent => {
                 self.timers.want_keepalive = false;


### PR DESCRIPTION
This applies several patches from other people's forks of boringtun where they have discovered issues around spurious rekeys during an active session.

Related: https://github.com/NordSecurity/boringtun/pull/8.
Related: https://github.com/cloudflare/boringtun/issues/363.