### PR TITLE
fix: use correct boolean comparison for scheduled handshake

### DIFF
--- a/boringtun/src/noise/timers.rs
+++ b/boringtun/src/noise/timers.rs
@@ -319,7 +319,7 @@ impl Tunn {
         if self
             .timers
             .send_handshake_at
-            .is_some_and(|deadline| deadline > time)
+            .is_some_and(|deadline| time > deadline)
         {
             self.timers.send_handshake_at = None;
 


### PR DESCRIPTION
In #46, we implemented the handshake jitter required by the WireGuard spec. Unfortunately, there was a boolean comparison bug where we compared the deadline, _when_ we need to send the next handshake incorrectly with the current time such that it was always more or less sent immediately IF `update_timers_at` was called within the deadline.