### PR TITLE
feat: expose `Tunn::next_timer_update`

### DIFF
--- a/boringtun/src/noise/timers.rs
+++ b/boringtun/src/noise/timers.rs
@@ -345,6 +345,13 @@ impl Tunn {
         TunnResult::Done
     }
 
+    /// Returns an [`Instant`] when [`Tunn::update_timers_at`] should be called again.
+    ///
+    /// If this returns `None`, you may call it at your usual desired precision (usually once a second is enough).
+    pub fn next_timer_update(&self) -> Option<Instant> {
+        self.timers.send_handshake_at
+    }
+
     #[deprecated(note = "Prefer `Tunn::time_since_last_handshake_at` to avoid time-impurity")]
     pub fn time_since_last_handshake(&self) -> Option<Duration> {
         self.time_since_last_handshake_at(Instant::now())


### PR DESCRIPTION
In boringtun, all timers are rounded to the nearest second and the docs recommend downstream applications to just call `update_timers_at` every second. This is problematic for the scheduled handshakes introduced in #46. The applied jitter is between 0 and 333ms but if `update_timers_at` is only called every second, the applied jitter doesn't really have any effect and instead, the handshake is just delayed by a full second (or whatever the interval is within which `update_timers_at` gets called).

In sans-IO designs, it is typical to expose a function that returns _when_ the state machine would like to be woken again. With this patch, we introduce such a function in the form of `next_timer_update`. At present, this only returns the next scheduled handshake as this is the only component that is somewhat critical and shouldn't just be handled with a 1s precision.