### PR TITLE
fix: don't initiate another handshake when one is in progress

### DIFF
--- a/boringtun/src/noise/mod.rs
+++ b/boringtun/src/noise/mod.rs
@@ -875,6 +875,28 @@ mod tests {
     }
 
     #[test]
+    fn multiple_update_calls_no_duplicate_handshakes() {
+        let mut now = Instant::now();
+        let mut num_handshakes = 0;
+        let mut buf = [0u8; 200];
+
+        let (mut my_tun, _their_tun) = create_two_tuns(now);
+
+        for _ in 0..200 {
+            now += Duration::from_millis(10);
+
+            if matches!(
+                my_tun.update_timers_at(&mut buf, now),
+                TunnResult::WriteToNetwork(_)
+            ) {
+                num_handshakes += 1;
+            }
+        }
+
+        assert_eq!(num_handshakes, 1);
+    }
+
+    #[test]
     fn new_handshake_after_two_mins() {
         let mut now = Instant::now();
 

--- a/boringtun/src/noise/timers.rs
+++ b/boringtun/src/noise/timers.rs
@@ -205,7 +205,7 @@ impl Tunn {
         self.update_session_timers(now);
 
         // Updating the session timer may expire our session, trigger a new one in that case.
-        if self.sessions[self.current % N_SESSIONS].is_none() {
+        if self.sessions[self.current % N_SESSIONS].is_none() && !self.handshake.is_in_progress() {
             handshake_initiation_required = true;
         }
 


### PR DESCRIPTION
In case `update_timers_at` is called repeatedly and we don't have a session, we would erroneously schedule multiple handshakes even though one is already in flight. By adding an additional condition, we avoid this.