### PR TITLE
chore: remove `mock-instant` dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -99,7 +99,6 @@ dependencies = [
  "ip_network_table",
  "jni",
  "libc",
- "mock_instant",
  "nix",
  "parking_lot",
  "rand",
@@ -680,12 +679,6 @@ checksum = "5aa361d4faea93603064a027415f07bd8e1d5c88c9fbf68bf56a285428fd79ce"
 dependencies = [
  "autocfg",
 ]
-
-[[package]]
-name = "mock_instant"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9366861eb2a2c436c20b12c8dbec5f798cea6b47ad99216be0282942e2c81ea0"
 
 [[package]]
 name = "nix"

--- a/boringtun/Cargo.toml
+++ b/boringtun/Cargo.toml
@@ -18,6 +18,7 @@ device = ["socket2", "thiserror"]
 jni-bindings = ["ffi-bindings", "jni"]
 ffi-bindings = ["tracing-subscriber"]
 mock-instant = []                      # Deprecated.
+mock_instant = []                      # Deprecated.
 
 [dependencies]
 base64 = "0.22"
@@ -40,7 +41,6 @@ aead = "0.5.0-pre.2"
 blake2 = "0.10"
 hmac = "0.12"
 jni = { version = "0.19.0", optional = true }
-mock_instant = { version = "0.3", optional = true } # Deprecated.
 socket2 = { version = "0.5.8", features = ["all"], optional = true }
 thiserror = { version = "1", optional = true }
 


### PR DESCRIPTION
With #45, the need for mocking `Instant` in order to test time-related functionality has been obsoleted. All functions simply take `Instant` as a parameter now. In order to preserve backwards-compatibility, an empty feature has been added that replaces the optional dependency.