### PR TITLE
fix: ensure responder does not initiate new handshake

### DIFF
--- a/boringtun/src/noise/timers.rs
+++ b/boringtun/src/noise/timers.rs
@@ -204,8 +204,11 @@ impl Tunn {
 
         self.update_session_timers(now);
 
-        // Updating the session timer may expire our session, trigger a new one in that case.
-        if self.sessions[self.current % N_SESSIONS].is_none() && !self.handshake.is_in_progress() {
+        // Updating the session timer may expire our session, trigger a new one in that case but only iff we initiated the previous one.
+        if self.sessions[self.current % N_SESSIONS].is_none()
+            && !self.handshake.is_in_progress()
+            && self.timers.is_initiator()
+        {
             handshake_initiation_required = true;
         }
 


### PR DESCRIPTION
As part of implementing the handshake jitter in #46, we also added a functionality to initiate a new handshake if the previous session has already expired. What we overlooked is that only the initiator of the previous session should do that. Otherwise, both nodes will start to establish a session and we end up having two active sessions at the same time.