### PR TITLE
refactor: colocate cookie expiration timer with cookie

### DIFF
--- a/boringtun/src/noise/mod.rs
+++ b/boringtun/src/noise/mod.rs
@@ -465,9 +465,8 @@ impl Tunn {
             local_idx = p.receiver_idx
         );
 
-        self.handshake.receive_cookie_reply(p)?;
+        self.handshake.receive_cookie_reply(p, now)?;
         self.timer_tick(TimerName::TimeLastPacketReceived, now);
-        self.timer_tick(TimerName::TimeCookieReceived, now);
 
         tracing::debug!("Did set cookie");
 

--- a/boringtun/src/noise/timers.rs
+++ b/boringtun/src/noise/timers.rs
@@ -17,7 +17,7 @@ pub(crate) const REJECT_AFTER_TIME: Duration = Duration::from_secs(180);
 const REKEY_ATTEMPT_TIME: Duration = Duration::from_secs(90);
 pub(crate) const REKEY_TIMEOUT: Duration = Duration::from_secs(5);
 const KEEPALIVE_TIMEOUT: Duration = Duration::from_secs(10);
-const COOKIE_EXPIRATION_TIME: Duration = Duration::from_secs(120);
+pub(crate) const COOKIE_EXPIRATION_TIME: Duration = Duration::from_secs(120);
 pub(crate) const MAX_JITTER: Duration = Duration::from_millis(333);
 
 #[derive(Debug)]
@@ -34,8 +34,6 @@ pub enum TimerName {
     TimeLastDataPacketReceived,
     /// Time we last send a DATA packet
     TimeLastDataPacketSent,
-    /// Time we last received a cookie
-    TimeCookieReceived,
     /// Time we last sent persistent keepalive
     TimePersistentKeepalive,
     Top,
@@ -217,8 +215,10 @@ impl Tunn {
             }
 
             // Clear cookie after COOKIE_EXPIRATION_TIME
-            if self.handshake.has_cookie()
-                && now - self.timers[TimeCookieReceived] >= COOKIE_EXPIRATION_TIME
+            if self
+                .handshake
+                .cookie_expiration()
+                .is_some_and(|deadline| now >= deadline)
             {
                 self.handshake.clear_cookie();
             }


### PR DESCRIPTION
Similar to #60, the expiration of a cookie is best tracked with the cookie itself. That way, clearing the cookie automatically invalidates the timer which prevents invalid state from lingering around.