### PR TITLE
refactor: remove unnecessary conditional

### DIFF
--- a/boringtun/src/noise/timers.rs
+++ b/boringtun/src/noise/timers.rs
@@ -147,12 +147,11 @@ impl Tunn {
             };
 
             if now.duration_since(session.established_at()) > REJECT_AFTER_TIME {
-                if let Some(session) = maybe_session.take() {
-                    tracing::debug!(
-                        message = "SESSION_EXPIRED(REJECT_AFTER_TIME)",
-                        session = session.receiving_index
-                    );
-                }
+                tracing::debug!(
+                    message = "SESSION_EXPIRED(REJECT_AFTER_TIME)",
+                    session = session.receiving_index
+                );
+                *maybe_session = None;
             }
         }
     }


### PR DESCRIPTION
We already match on the `maybe_session` a few lines up, thus we know that it is `Some` when we enter this `if`. All we need to do is set it to `None` to invalidate it.