### PR TITLE
fix: don't send packets on almost expired sessions

### DIFF
--- a/boringtun/src/noise/mod.rs
+++ b/boringtun/src/noise/mod.rs
@@ -311,7 +311,10 @@ impl Tunn {
         now: Instant,
     ) -> TunnResult<'a> {
         let current = self.current;
-        if let Some(ref session) = self.sessions[current % N_SESSIONS] {
+        if let Some(session) = self.sessions[current % N_SESSIONS]
+            .as_ref()
+            .filter(|s| s.should_use_at(now))
+        {
             // Send the packet using an established session
             let packet = match session.format_packet_data(src, dst) {
                 Ok(p) => p,
@@ -713,7 +716,7 @@ mod tests {
 
     use super::*;
     use rand::{rngs::OsRng, RngCore};
-    use timers::{KEEPALIVE_TIMEOUT, MAX_JITTER, REJECT_AFTER_TIME};
+    use timers::{KEEPALIVE_TIMEOUT, MAX_JITTER, REJECT_AFTER_TIME, SHOULD_NOT_USE_AFTER_TIME};
     use tracing::Level;
 
     fn create_two_tuns(now: Instant) -> (Tunn, Tunn) {
@@ -957,6 +960,32 @@ mod tests {
             TunnResult::Done
         ));
         update_timer_results_in_handshake(&mut my_tun, &mut now);
+    }
+
+    /// If a tunnel is idle for close to 120s without sending a packet,
+    /// no new handshake is performed by the initiator.
+    /// This can lead to a race-condition where the sender sends a packet on an almost expired session
+    /// and by the time it is received, the session is expired.
+    #[test]
+    fn new_handshake_on_packet_for_session_that_is_about_to_expire() {
+        let mut now = Instant::now();
+
+        let (mut my_tun, _their_tun) = create_two_tuns_and_handshake(now);
+        let mut my_dst = [0u8; 1024];
+
+        now += SHOULD_NOT_USE_AFTER_TIME + Duration::from_secs(1);
+
+        let sent_packet_buf = create_ipv4_udp_packet();
+        let data = my_tun.encapsulate_at(&sent_packet_buf, &mut my_dst, now);
+
+        let TunnResult::WriteToNetwork(data) = data else {
+            panic!("Expected `WriteToNetwork`")
+        };
+
+        assert!(matches!(
+            Tunn::parse_incoming_packet(data).unwrap(),
+            Packet::HandshakeInit(_)
+        ));
     }
 
     #[test]

--- a/boringtun/src/noise/session.rs
+++ b/boringtun/src/noise/session.rs
@@ -1,7 +1,10 @@
 // Copyright (c) 2019 Cloudflare, Inc. All rights reserved.
 // SPDX-License-Identifier: BSD-3-Clause
 
-use super::{timers::REJECT_AFTER_TIME, PacketData};
+use super::{
+    timers::{REJECT_AFTER_TIME, SHOULD_NOT_USE_AFTER_TIME},
+    PacketData,
+};
 use crate::noise::errors::WireGuardError;
 use parking_lot::Mutex;
 use ring::aead::{Aad, LessSafeKey, Nonce, UnboundKey, CHACHA20_POLY1305};
@@ -186,6 +189,10 @@ impl Session {
 
     pub(crate) fn expired_at(&self, time: Instant) -> bool {
         time > self.established_at + REJECT_AFTER_TIME
+    }
+
+    pub(crate) fn should_use_at(&self, time: Instant) -> bool {
+        time <= self.established_at + SHOULD_NOT_USE_AFTER_TIME
     }
 
     /// Returns true if receiving counter is good to use

--- a/boringtun/src/noise/session.rs
+++ b/boringtun/src/noise/session.rs
@@ -1,7 +1,7 @@
 // Copyright (c) 2019 Cloudflare, Inc. All rights reserved.
 // SPDX-License-Identifier: BSD-3-Clause
 
-use super::PacketData;
+use super::{timers::REJECT_AFTER_TIME, PacketData};
 use crate::noise::errors::WireGuardError;
 use parking_lot::Mutex;
 use ring::aead::{Aad, LessSafeKey, Nonce, UnboundKey, CHACHA20_POLY1305};
@@ -182,6 +182,10 @@ impl Session {
 
     pub(crate) fn established_at(&self) -> Instant {
         self.established_at
+    }
+
+    pub(crate) fn expired_at(&self, time: Instant) -> bool {
+        time > self.established_at + REJECT_AFTER_TIME
     }
 
     /// Returns true if receiving counter is good to use

--- a/boringtun/src/noise/timers.rs
+++ b/boringtun/src/noise/timers.rs
@@ -20,6 +20,16 @@ pub(crate) const KEEPALIVE_TIMEOUT: Duration = Duration::from_secs(10);
 pub(crate) const COOKIE_EXPIRATION_TIME: Duration = Duration::from_secs(120);
 pub(crate) const MAX_JITTER: Duration = Duration::from_millis(333);
 
+/// Time-period after which a session should no longer be used for new packets.
+///
+/// In order for [`REKEY_AFTER_TIME`] to take effect, at least one data packet needs to be sent on a session.
+/// If this data packet is sent close to the expire of the session ([`REJECT_AFTER_TIME`]), the session
+/// may be expired by the time the packet reaches the receiver (and thus will not be able to be decrypted).
+///
+/// To avoid this, we stop using the session after [`REJECT_AFTER_TIME`] - [`KEEPALIVE_TIMEOUT`].
+pub(crate) const SHOULD_NOT_USE_AFTER_TIME: Duration =
+    Duration::from_secs(REJECT_AFTER_TIME.as_secs() - KEEPALIVE_TIMEOUT.as_secs());
+
 #[derive(Debug)]
 pub enum TimerName {
     /// Time when last handshake was completed

--- a/boringtun/src/noise/timers.rs
+++ b/boringtun/src/noise/timers.rs
@@ -94,6 +94,10 @@ impl Timers {
         self.is_initiator
     }
 
+    pub(crate) fn is_responder(&self) -> bool {
+        !self.is_initiator()
+    }
+
     // We don't really clear the timers, but we set them to the current time to
     // so the reference time frame is the same
     pub(super) fn clear(&mut self, now: Instant) {

--- a/boringtun/src/noise/timers.rs
+++ b/boringtun/src/noise/timers.rs
@@ -161,7 +161,7 @@ impl Tunn {
                 continue;
             };
 
-            if now.duration_since(session.established_at()) > REJECT_AFTER_TIME {
+            if session.expired_at(now) {
                 tracing::debug!(
                     message = "SESSION_EXPIRED(REJECT_AFTER_TIME)",
                     session = session.receiving_index


### PR DESCRIPTION
WireGuard has several internal timers. For example, if we have previously sent a data packet on a session and the session becomes older than 120s, we automatically perform a re-key. This ensures session keys are constantly rolled over on sessions that are actively used. If a session is not used at all, it expires after 180s.

There is a race condition where a packet may be sent on a previously entirely idle session but just before it expires, i.e. at second 179 of the session. In that case, the sending party will still happily encrypt it but depending on the latency to the receiver, the session may be expired on their end by the time it arrives.

To fix this, we introduce a new timer called `SHOULD_NOT_USE_AFTER_TIME` which is defined as `REJECT_AFTER_TIME` - `KEEPALIVE_TIMEOUT`. If we attempt to send a packet on a session that is about to expire and we are the initiator of the current session, we instead buffer the packet and emit a new handshake.

It is important that only the current initiator performs this check, otherwise we would introduce another race condition where the responder would initiate the next session in case it wants to sends an application-level reply just after `SHOULD_NOT_USE_AFTER_TIME`.