### PR TITLE
refactor: simplify passive keepalive

### DIFF
--- a/boringtun/src/noise/timers.rs
+++ b/boringtun/src/noise/timers.rs
@@ -3,7 +3,6 @@
 
 use super::errors::WireGuardError;
 use crate::noise::{Tunn, TunnResult, N_SESSIONS};
-use std::mem;
 use std::ops::{Index, IndexMut};
 
 use rand::Rng;
@@ -327,8 +326,7 @@ impl Tunn {
             if !handshake_initiation_required {
                 // If a packet has been received from a given peer, but we have not sent one back
                 // to the given peer in KEEPALIVE ms, we send an empty packet.
-                if now - aut_packet_sent >= KEEPALIVE_TIMEOUT
-                    && mem::replace(&mut self.timers.want_passive_keepalive, false)
+                if now - aut_packet_sent >= KEEPALIVE_TIMEOUT && self.timers.want_passive_keepalive
                 {
                     tracing::debug!("KEEPALIVE(KEEPALIVE_TIMEOUT)");
                     keepalive_required = true;

--- a/boringtun/src/noise/timers.rs
+++ b/boringtun/src/noise/timers.rs
@@ -126,11 +126,13 @@ impl Tunn {
     pub(super) fn timer_tick(&mut self, timer_name: TimerName, now: Instant) {
         match timer_name {
             TimeLastPacketReceived => {
-                self.timers.want_keepalive = true;
                 self.timers.want_handshake_at = None;
             }
             TimeLastPacketSent => {
                 self.timers.want_keepalive = false;
+            }
+            TimeLastDataPacketReceived => {
+                self.timers.want_keepalive = true;
             }
             TimeLastDataPacketSent => {
                 match self.timers.want_handshake_at {
@@ -325,8 +327,7 @@ impl Tunn {
             if !handshake_initiation_required {
                 // If a packet has been received from a given peer, but we have not sent one back
                 // to the given peer in KEEPALIVE ms, we send an empty packet.
-                if data_packet_received > aut_packet_sent
-                    && now - aut_packet_sent >= KEEPALIVE_TIMEOUT
+                if now - aut_packet_sent >= KEEPALIVE_TIMEOUT
                     && mem::replace(&mut self.timers.want_keepalive, false)
                 {
                     tracing::debug!("KEEPALIVE(KEEPALIVE_TIMEOUT)");

--- a/boringtun/src/noise/timers.rs
+++ b/boringtun/src/noise/timers.rs
@@ -401,4 +401,9 @@ impl Tunn {
             None
         }
     }
+
+    #[cfg(test)]
+    pub fn set_persistent_keepalive(&mut self, keepalive: u16) {
+        self.timers.persistent_keepalive = keepalive as usize;
+    }
 }


### PR DESCRIPTION
WireGuard has a passive keepalive mechanism. To quote the spec:

>  If a peer has received a validly-authenticated transport data message (section 5.4.6), but does not have any packets
itself to send back for Keepalive-Timeout seconds, it sends a keepalive message.

This is currently implemented correctly in `boringtun` but it is somewhat convoluted.

1. On various parts in the code, the internal timers are ticked over. For example, when we receive keepalive messages or data messages.
2. Whether or not we should send a passive keepalive is tracked in the `want_keepalive` boolean.
3. This boolean is set whenever we receive _any_ packet (including keepalives). This is a bug.
4. The above bug is mitigated because of an additional condition that the last received data packet must be after the last sent packet.
5. Lastly, the `want_keepalive` boolean is checked and directly set to false as part of our timer code. Combining these two things makes the code hard to reason about.

We can simplify this greatly by directly tracking the timestamp, when a keepalive is due. The new `want_keepalive_at` timer is set every time we receive a data packet and cleared every time we send a packet. In `update_timers_at`, we simply check if `now` has surpassed that timer and send a keepalive if that is the case.

As a bonus, this functionality is now also unit-tested.