### PR TITLE
fix: allow `unused_attributes`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -85,7 +85,7 @@ dependencies = [
 
 [[package]]
 name = "boringtun"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "aead",
  "base64",

--- a/boringtun/Cargo.toml
+++ b/boringtun/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "boringtun"
 description = "an implementation of the WireGuard® protocol designed for portability and speed"
-version = "0.6.0"
+version = "0.6.1"
 authors = [
     "Noah Kennedy <nkennedy@cloudflare.com>",
     "Andy Grover <agrover@cloudflare.com>",

--- a/boringtun/src/jni.rs
+++ b/boringtun/src/jni.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: BSD-3-Clause
 
 // temporary, we need to do some verification around these bindings later
-#![allow(clippy::missing_safety_doc)]
+#![allow(clippy::missing_safety_doc, unused_attributes)]
 
 /// JNI bindings for BoringTun library
 use std::os::raw::c_char;


### PR DESCRIPTION
Rustc extended the `unused_attributes` lint to warn on the use of `no_mangle` with `export_name`. We can't fix this though because `cargo semver-checks` thinks it is a breaking change so we allow it instead.