### PR TITLE
refactor: use `io::Error::other`

### DIFF
--- a/boringtun/src/ffi/mod.rs
+++ b/boringtun/src/ffi/mod.rs
@@ -18,7 +18,7 @@ use tracing_subscriber::fmt;
 
 use crate::serialization::KeyBytes;
 use std::ffi::{CStr, CString};
-use std::io::{Error, ErrorKind, Write};
+use std::io::{Error, Write};
 use std::os::raw::c_char;
 use std::panic;
 use std::ptr;
@@ -177,10 +177,7 @@ impl Write for FFIFunctionPointerWriter {
             unsafe { (self.log_func)(c_string.as_ptr()) }
             Ok(buf.len())
         } else {
-            Err(Error::new(
-                ErrorKind::Other,
-                "Failed to create CString from buffer.",
-            ))
+            Err(Error::other("Failed to create CString from buffer."))
         }
     }
 


### PR DESCRIPTION
As suggested by a new clippy lint.