### PR TITLE
refactor: use `Buf` trait for `encapsulate_at`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -90,6 +90,7 @@ dependencies = [
  "aead",
  "base64",
  "blake2",
+ "bytes",
  "chacha20poly1305",
  "constant_time_eq",
  "criterion",
@@ -144,9 +145,9 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
-version = "1.1.0"
+version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4872d67bab6358e59559027aa3b9157c53d9358c51423c17554809a8858e0f8"
+checksum = "d71b6127be86fdcfddb610f7182ac57211d4b18a3e9c82eb2d17662f2227ad6a"
 
 [[package]]
 name = "cast"

--- a/boringtun/Cargo.toml
+++ b/boringtun/Cargo.toml
@@ -22,6 +22,7 @@ mock_instant = []                      # Deprecated.
 
 [dependencies]
 base64 = "0.22"
+bytes = "1.10.1"
 hex = "0.4"
 untrusted = "0.9.0"
 libc = "0.2"

--- a/boringtun/src/device/mod.rs
+++ b/boringtun/src/device/mod.rs
@@ -821,7 +821,7 @@ impl Device {
 
                     match peer
                         .tunnel
-                        .encapsulate_at(src, &mut t.dst_buf[..], Instant::now())
+                        .encapsulate_at(&*src, &mut t.dst_buf[..], Instant::now())
                     {
                         TunnResult::Done => {}
                         TunnResult::Err(e) => {

--- a/boringtun/src/noise/timers.rs
+++ b/boringtun/src/noise/timers.rs
@@ -366,7 +366,7 @@ impl Tunn {
         }
 
         if keepalive_required {
-            return self.encapsulate_at(&[], dst, now);
+            return self.encapsulate_at(&[] as &[u8], dst, now);
         }
 
         TunnResult::Done


### PR DESCRIPTION
At present, the `encapsulate_at` function (which we added in our fork) takes a slice of bytes that represents the IP packet to encapsulate. This mirrors the impure `encapsulate` function from upstream `boringtun`. Passing a slice is cheap in Rust because it is just a pointer. Slices also guarantee that the memory they point to is one continuous allocation.

In Firezone, we need to parse and manipulate IP packets. To make this easier, we are working towards a new in-memory representation that directly stores the parsed contents and not just the memory-slice.

With the present API of `boringtun`, this would mean we would have to incur one extra copy of each packet before we encrypt it in order to have a continuous memory allocation again. This is unnecessary once you look at `boringtun`s internals. Here, the memory slice just gets copied to the destination buffer anyway and then encrypted in-place.

As a result, we can create a more flexible API here by accepting something that implements the `bytes::Buf` trait. `Buf` represents bytes that are stored in memory but might not necessarily be one continuous allocation. It is therefore the perfect API for our needs as it allows us to pass in an adapter struct that borrows from our IP packet representation and simply returns chunks of memory of the internal representation.