### PR TITLE
feat: expose remote static public key

### DIFF
--- a/boringtun/src/noise/handshake.rs
+++ b/boringtun/src/noise/handshake.rs
@@ -438,6 +438,10 @@ impl Handshake {
         }
     }
 
+    pub(crate) fn remote_static_public(&self) -> x25519::PublicKey {
+        self.params.peer_static_public
+    }
+
     pub(crate) fn is_in_progress(&self) -> bool {
         !matches!(self.state, HandshakeState::None | HandshakeState::Expired)
     }

--- a/boringtun/src/noise/mod.rs
+++ b/boringtun/src/noise/mod.rs
@@ -253,6 +253,10 @@ impl Tunn {
         }
     }
 
+    pub fn remote_static_public(&self) -> x25519::PublicKey {
+        self.handshake.remote_static_public()
+    }
+
     /// Update the private key and clear existing sessions
     #[deprecated(note = "Prefer `Tunn::set_static_private_at` to avoid time-impurity")]
     pub fn set_static_private(


### PR DESCRIPTION
In order to check, which remote public key a tunnel is configured for, we need to expose it publicly.