### PR TITLE
chore: log whether the expired session is the current one

### DIFF
--- a/boringtun/src/noise/timers.rs
+++ b/boringtun/src/noise/timers.rs
@@ -183,15 +183,18 @@ impl Tunn {
     }
 
     fn expire_sessions(&mut self, now: Instant) {
-        for maybe_session in self.sessions.iter_mut() {
+        for (idx, maybe_session) in self.sessions.iter_mut().enumerate() {
             let Some(session) = maybe_session else {
                 continue;
             };
 
+            let is_current = (self.current % N_SESSIONS) == idx;
+
             if session.expired_at(now) {
                 tracing::debug!(
-                    message = "SESSION_EXPIRED(REJECT_AFTER_TIME)",
-                    session = session.receiving_index
+                    session = session.receiving_index,
+                    %is_current,
+                    "SESSION_EXPIRED(REJECT_AFTER_TIME)"
                 );
                 *maybe_session = None;
             }


### PR DESCRIPTION
WireGuard ensures perfect-forward secrecy by rolling over to a new session every 2 minutes. To ensure this happens smoothly, an old session isn't immediately discarded. This allows peers to still decrypt packets from old sessions for an additional minute whilst the new session is being established. Thus, packets already in-flight can still be handled.

An artifact of this designs is that the old session will then expire with the timer and still print `SESSION_EXPIRED(REJECT_AFTER_TIME)`. Seeing only this in the logs may be alerting when in fact it is completely normal. To make this more obvious, we add a boolean `is_current` to the log message that tells us whether the expired session is the current one. If `is_current = false`, the log is harmless.