### PR TITLE
chore: expose `preshared_key` from `NoiseParams`

### DIFF
--- a/boringtun/src/noise/handshake.rs
+++ b/boringtun/src/noise/handshake.rs
@@ -442,6 +442,10 @@ impl Handshake {
         self.params.peer_static_public
     }
 
+    pub(crate) fn preshared_key(&self) -> Option<[u8; 32]> {
+        self.params.preshared_key
+    }
+
     pub(crate) fn is_in_progress(&self) -> bool {
         !matches!(self.state, HandshakeState::None | HandshakeState::Expired)
     }

--- a/boringtun/src/noise/mod.rs
+++ b/boringtun/src/noise/mod.rs
@@ -257,6 +257,10 @@ impl Tunn {
         self.handshake.remote_static_public()
     }
 
+    pub fn preshared_key(&self) -> Option<[u8; 32]> {
+        self.handshake.preshared_key()
+    }
+
     /// Update the private key and clear existing sessions
     #[deprecated(note = "Prefer `Tunn::set_static_private_at` to avoid time-impurity")]
     pub fn set_static_private(


### PR DESCRIPTION
In order to detect whether two tunnels are the exact same, we not only need to compare the remote and our public key but also the `preshared_key`. If it differs, the two nodes will not be able to make a handshake despite the public keys being the same.

In order to check this, `Tunn` needs to expose the `preshared_key`.