### PR TITLE
chore: bump `x25519-dalek` and `rand` dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -85,7 +85,7 @@ dependencies = [
 
 [[package]]
 name = "boringtun"
-version = "0.6.1"
+version = "0.7.0"
 dependencies = [
  "aead",
  "base64",
@@ -310,9 +310,9 @@ checksum = "3d52eff69cd5e647efe296129160853a42795992097e8af39800e1060caeea9b"
 
 [[package]]
 name = "cpufeatures"
-version = "0.2.9"
+version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a17b76ff3a4162b0b27f354a0c87015ddad39d35f9c0c36607a3bdd175dde1f1"
+checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
 dependencies = [
  "libc",
 ]
@@ -403,15 +403,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
 dependencies = [
  "generic-array",
- "rand_core",
+ "rand_core 0.6.4",
  "typenum",
 ]
 
 [[package]]
 name = "curve25519-dalek"
-version = "4.1.3"
+version = "5.0.0-pre.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97fb8b7c4503de7d6ae7b42ab72a5a59857b4c937ec27a3d4539dba95b5ab2be"
+checksum = "6f9200d1d13637f15a6acb71e758f64624048d85b31a5fdbfd8eca1e2687d0b7"
 dependencies = [
  "cfg-if",
  "cpufeatures",
@@ -445,9 +445,9 @@ dependencies = [
 
 [[package]]
 name = "digest"
-version = "0.10.3"
+version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2fb860ca6fafa5552fb6d0e816a69c8e49f0908bf524e30a90d97c85892d506"
+checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
  "block-buffer",
  "crypto-common",
@@ -471,9 +471,9 @@ dependencies = [
 
 [[package]]
 name = "fiat-crypto"
-version = "0.2.9"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28dea519a9695b9977216879a3ebfddf92f1c08c05d984f8996aecd6ecdc811d"
+checksum = "64cd1e32ddd350061ae6edb1b082d7c54915b5c672c389143b9a63403a109f24"
 
 [[package]]
 name = "generic-array"
@@ -493,7 +493,19 @@ checksum = "be4136b2a15dd319360be1c07d9933517ccf0be8f16bf62a3bee4f0d618df427"
 dependencies = [
  "cfg-if",
  "libc",
- "wasi",
+ "wasi 0.11.0+wasi-snapshot-preview1",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26145e563e54f2cadc477553f1ec5ee650b00862f0a58bcd12cbdc5f0ea2d2f4"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi",
+ "wasi 0.14.7+wasi-0.2.4",
 ]
 
 [[package]]
@@ -836,24 +848,29 @@ dependencies = [
 ]
 
 [[package]]
-name = "rand"
-version = "0.8.5"
+name = "r-efi"
+version = "5.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
+checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
+
+[[package]]
+name = "rand"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
 dependencies = [
- "libc",
  "rand_chacha",
- "rand_core",
+ "rand_core 0.9.3",
 ]
 
 [[package]]
 name = "rand_chacha"
-version = "0.3.1"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
+checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
 dependencies = [
  "ppv-lite86",
- "rand_core",
+ "rand_core 0.9.3",
 ]
 
 [[package]]
@@ -862,7 +879,16 @@ version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
- "getrandom",
+ "getrandom 0.2.10",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "99d9a13982dcf210057a8a78572b2217b667c3beacbf3a0d8b454f6f82837d38"
+dependencies = [
+ "getrandom 0.3.3",
 ]
 
 [[package]]
@@ -921,7 +947,7 @@ checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
 dependencies = [
  "cc",
  "cfg-if",
- "getrandom",
+ "getrandom 0.2.10",
  "libc",
  "untrusted",
  "windows-sys 0.52.0",
@@ -1033,9 +1059,9 @@ checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
 
 [[package]]
 name = "subtle"
-version = "2.4.1"
+version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6bdef32e8150c2a081110b42772ffe7d7c9032b606bc226c8260fd97e0976601"
+checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "syn"
@@ -1057,18 +1083,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-ident",
-]
-
-[[package]]
-name = "synstructure"
-version = "0.12.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f36bdaa60a83aca3921b5259d5400cbf5e90fc51931376a9bd4a0eb79aa7210f"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 1.0.98",
- "unicode-xid",
 ]
 
 [[package]]
@@ -1218,12 +1232,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5bd2fe26506023ed7b5e1e315add59d6f584c621d037f9368fea9cfb988f368c"
 
 [[package]]
-name = "unicode-xid"
-version = "0.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "957e51f3646910546462e67d5f7599b9e4fb8acdd304b087a6494730f9eebf04"
-
-[[package]]
 name = "universal-hash"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1267,6 +1275,24 @@ name = "wasi"
 version = "0.11.0+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
+
+[[package]]
+name = "wasi"
+version = "0.14.7+wasi-0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "883478de20367e224c0090af9cf5f9fa85bed63a95c1abf3afc5c083ebc06e8c"
+dependencies = [
+ "wasip2",
+]
+
+[[package]]
+name = "wasip2"
+version = "1.0.1+wasi-0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0562428422c63773dad2c345a1882263bbf4d65cf3f42e90921f787ef5ad58e7"
+dependencies = [
+ "wit-bindgen",
+]
 
 [[package]]
 name = "wasm-bindgen"
@@ -1446,13 +1472,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
-name = "x25519-dalek"
-version = "2.0.1"
+name = "wit-bindgen"
+version = "0.46.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7e468321c81fb07fa7f4c636c3972b9100f0346e5b6a9f2bd0603a52f7ed277"
+checksum = "f17a85883d4e6d00e8a97c586de764dabcc06133f7f1d55dce5cdc070ad7fe59"
+
+[[package]]
+name = "x25519-dalek"
+version = "3.0.0-pre.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a45998121837fd8c92655d2334aa8f3e5ef0645cdfda5b321b13760c548fd55"
 dependencies = [
  "curve25519-dalek",
- "rand_core",
+ "rand_core 0.9.3",
  "serde",
  "zeroize",
 ]
@@ -1483,18 +1515,3 @@ name = "zeroize"
 version = "1.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "20b578acffd8516a6c3f2a1bdefc1ec37e547bb4e0fb8b6b01a4cafc886b4442"
-dependencies = [
- "zeroize_derive",
-]
-
-[[package]]
-name = "zeroize_derive"
-version = "1.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f8f187641dad4f680d25c4bfc4225b418165984179f26ca76ec4fb6441d3a17"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 1.0.98",
- "synstructure",
-]

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 ## How to use this fork
 
 This repository is a fork of https://github.com/cloudflare/boringtun.
-We aim for 100% API compatibility with upstream.
+We aim for a high API compatibility with upstream.
 As such, the best way to use this fork is by patching the `boringtun` dependency in your `Cargo.toml`:
 
 ```toml
@@ -14,6 +14,9 @@ boringtun = { git = "https://github.com/firezone/boringtun", branch = "master" }
 ```
 
 The full list of patches in this fork over upstream can be seen in [here](https://github.com/cloudflare/boringtun/compare/master...firezone:boringtun:master).
+
+Up until [37739b0a366ca73029ada59c043bf1d3e56f97f6](https://github.com/firezone/boringtun/commit/37739b0a366ca73029ada59c043bf1d3e56f97f6), all changes are fully backwards-compatible.
+Going forward, we bumped the version to 0.7 and made some breaking changes like bumping `x25519-dalek` and `rand` as well as removing some deprecated APIs.
 
 ## Warning
 Boringtun is currently undergoing a restructuring. You should probably not rely on or link to 

--- a/boringtun-cli/Cargo.toml
+++ b/boringtun-cli/Cargo.toml
@@ -16,6 +16,6 @@ tracing-subscriber = "0.3.20"
 tracing-appender = "0.2.3"
 
 [dependencies.boringtun]
-version = "0.6.0"
+version = "0.7.0"
 path = "../boringtun"
 features = ["device"]

--- a/boringtun/Cargo.toml
+++ b/boringtun/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "boringtun"
 description = "an implementation of the WireGuard® protocol designed for portability and speed"
-version = "0.6.1"
+version = "0.7.0"
 authors = [
     "Noah Kennedy <nkennedy@cloudflare.com>",
     "Andy Grover <agrover@cloudflare.com>",
@@ -31,11 +31,12 @@ tracing-subscriber = { version = "0.3", features = ["fmt"], optional = true }
 ip_network = "0.4.1"
 ip_network_table = "0.2.0"
 ring = "0.17"
-x25519-dalek = { version = "2.0.1", features = [
+x25519-dalek = { version = "=3.0.0-pre.1", features = [
     "reusable_secrets",
     "static_secrets",
+    "os_rng"
 ] }
-rand = "0.8.5"
+rand = "0.9.1"
 chacha20poly1305 = "0.10.1"
 aead = "0.5.2"
 blake2 = "0.10"

--- a/boringtun/benches/crypto_benches/chacha20poly1305_benching.rs
+++ b/boringtun/benches/crypto_benches/chacha20poly1305_benching.rs
@@ -1,6 +1,6 @@
 use aead::{AeadInPlace, KeyInit};
 use criterion::{BenchmarkId, Criterion, Throughput};
-use rand::{rngs::OsRng, RngCore};
+use rand::{rngs::OsRng, RngCore, TryRngCore};
 use ring::aead::{Aad, LessSafeKey, Nonce, UnboundKey, CHACHA20_POLY1305};
 
 fn chacha20poly1305_ring(key_bytes: &[u8], buf: &mut [u8]) {
@@ -49,7 +49,7 @@ pub fn bench_chacha20poly1305(c: &mut Criterion) {
                 let mut key = [0; 32];
                 let mut buf = vec![0; i + 16];
 
-                let mut rng = OsRng;
+                let mut rng = OsRng.unwrap_err();
 
                 rng.fill_bytes(&mut key);
                 rng.fill_bytes(&mut buf);
@@ -65,7 +65,7 @@ pub fn bench_chacha20poly1305(c: &mut Criterion) {
                 let mut key = [0; 32];
                 let mut buf = vec![0; i + 16];
 
-                let mut rng = OsRng;
+                let mut rng = OsRng.unwrap_err();
 
                 rng.fill_bytes(&mut key);
                 rng.fill_bytes(&mut buf);

--- a/boringtun/benches/crypto_benches/x25519_public_key_benching.rs
+++ b/boringtun/benches/crypto_benches/x25519_public_key_benching.rs
@@ -1,5 +1,5 @@
 use criterion::Criterion;
-use rand::rngs::OsRng;
+use rand::{rngs::OsRng, TryRngCore};
 
 pub fn bench_x25519_public_key(c: &mut Criterion) {
     let mut group = c.benchmark_group("x25519_public_key");
@@ -8,7 +8,7 @@ pub fn bench_x25519_public_key(c: &mut Criterion) {
 
     group.bench_function("x25519_public_key_dalek", |b| {
         b.iter(|| {
-            let secret_key = x25519_dalek::StaticSecret::random_from_rng(OsRng);
+            let secret_key = x25519_dalek::StaticSecret::random_from_rng(&mut OsRng.unwrap_mut());
             let public_key = x25519_dalek::PublicKey::from(&secret_key);
 
             (secret_key, public_key)

--- a/boringtun/benches/crypto_benches/x25519_shared_key_benching.rs
+++ b/boringtun/benches/crypto_benches/x25519_shared_key_benching.rs
@@ -1,5 +1,5 @@
 use criterion::{BatchSize, Criterion};
-use rand::rngs::OsRng;
+use rand::{rngs::OsRng, TryRngCore};
 
 pub fn bench_x25519_shared_key(c: &mut Criterion) {
     let mut group = c.benchmark_group("x25519_shared_key");
@@ -7,11 +7,12 @@ pub fn bench_x25519_shared_key(c: &mut Criterion) {
     group.sample_size(1000);
 
     group.bench_function("x25519_shared_key_dalek", |b| {
-        let public_key =
-            x25519_dalek::PublicKey::from(&x25519_dalek::StaticSecret::random_from_rng(OsRng));
+        let public_key = x25519_dalek::PublicKey::from(
+            &x25519_dalek::StaticSecret::random_from_rng(&mut OsRng.unwrap_mut()),
+        );
 
         b.iter_batched(
-            || x25519_dalek::StaticSecret::random_from_rng(OsRng),
+            || x25519_dalek::StaticSecret::random_from_rng(&mut OsRng.unwrap_mut()),
             |secret_key| secret_key.diffie_hellman(&public_key),
             BatchSize::SmallInput,
         );

--- a/boringtun/src/device/integration_tests/mod.rs
+++ b/boringtun/src/device/integration_tests/mod.rs
@@ -10,6 +10,7 @@ mod tests {
     use base64::prelude::*;
     use hex::encode;
     use rand::rngs::OsRng;
+    use rand::TryRngCore;
     use ring::rand::{SecureRandom, SystemRandom};
     use std::fmt::Write as _;
     use std::io::{BufRead, BufReader, Read, Write};
@@ -87,7 +88,7 @@ mod tests {
         /// Create a new peer with a given endpoint and a list of allowed IPs
         fn new(endpoint: SocketAddr, allowed_ips: Vec<AllowedIp>) -> Peer {
             Peer {
-                key: StaticSecret::random_from_rng(OsRng),
+                key: StaticSecret::random_from_rng(&mut OsRng.unwrap_mut()),
                 endpoint,
                 allowed_ips,
                 container_name: None,
@@ -484,7 +485,7 @@ mod tests {
     /// Test if wireguard starts and creates a unix socket that we can use to set settings
     fn test_wireguard_set() {
         let port = next_port();
-        let private_key = StaticSecret::random_from_rng(OsRng);
+        let private_key = StaticSecret::random_from_rng(&mut OsRng.unwrap_mut());
         let own_public_key = PublicKey::from(&private_key);
 
         let wg = WGHandle::init("192.0.2.0".parse().unwrap(), "::2".parse().unwrap());
@@ -502,7 +503,7 @@ mod tests {
             )
         );
 
-        let peer_key = StaticSecret::random_from_rng(OsRng);
+        let peer_key = StaticSecret::random_from_rng(&mut OsRng.unwrap_mut());
         let peer_pub_key = PublicKey::from(&peer_key);
         let endpoint = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(172, 0, 0, 1)), 50001);
         let allowed_ips = [
@@ -551,7 +552,7 @@ mod tests {
     #[ignore]
     fn test_wg_start_ipv4_non_connected() {
         let port = next_port();
-        let private_key = StaticSecret::random_from_rng(OsRng);
+        let private_key = StaticSecret::random_from_rng(&mut OsRng.unwrap_mut());
         let public_key = PublicKey::from(&private_key);
         let addr_v4 = next_ip();
         let addr_v6 = next_ip_v6();
@@ -598,7 +599,7 @@ mod tests {
     #[ignore]
     fn test_wg_start_ipv4() {
         let port = next_port();
-        let private_key = StaticSecret::random_from_rng(OsRng);
+        let private_key = StaticSecret::random_from_rng(&mut OsRng.unwrap_mut());
         let public_key = PublicKey::from(&private_key);
         let addr_v4 = next_ip();
         let addr_v6 = next_ip_v6();
@@ -634,7 +635,7 @@ mod tests {
     /// Test if wireguard can handle simple ipv6 connections
     fn test_wg_start_ipv6() {
         let port = next_port();
-        let private_key = StaticSecret::random_from_rng(OsRng);
+        let private_key = StaticSecret::random_from_rng(&mut OsRng.unwrap_mut());
         let public_key = PublicKey::from(&private_key);
         let addr_v4 = next_ip();
         let addr_v6 = next_ip_v6();
@@ -670,7 +671,7 @@ mod tests {
     #[cfg(target_os = "linux")] // Can't make docker work with ipv6 on macOS ATM
     fn test_wg_start_ipv6_endpoint() {
         let port = next_port();
-        let private_key = StaticSecret::random_from_rng(OsRng);
+        let private_key = StaticSecret::random_from_rng(&mut OsRng.unwrap_mut());
         let public_key = PublicKey::from(&private_key);
         let addr_v4 = next_ip();
         let addr_v6 = next_ip_v6();
@@ -709,7 +710,7 @@ mod tests {
     #[cfg(target_os = "linux")] // Can't make docker work with ipv6 on macOS ATM
     fn test_wg_start_ipv6_endpoint_not_connected() {
         let port = next_port();
-        let private_key = StaticSecret::random_from_rng(OsRng);
+        let private_key = StaticSecret::random_from_rng(&mut OsRng.unwrap_mut());
         let public_key = PublicKey::from(&private_key);
         let addr_v4 = next_ip();
         let addr_v6 = next_ip_v6();
@@ -758,7 +759,7 @@ mod tests {
     #[ignore]
     fn test_wg_concurrent() {
         let port = next_port();
-        let private_key = StaticSecret::random_from_rng(OsRng);
+        let private_key = StaticSecret::random_from_rng(&mut OsRng.unwrap_mut());
         let public_key = PublicKey::from(&private_key);
         let addr_v4 = next_ip();
         let addr_v6 = next_ip_v6();
@@ -809,7 +810,7 @@ mod tests {
     #[ignore]
     fn test_wg_concurrent_v6() {
         let port = next_port();
-        let private_key = StaticSecret::random_from_rng(OsRng);
+        let private_key = StaticSecret::random_from_rng(&mut OsRng.unwrap_mut());
         let public_key = PublicKey::from(&private_key);
         let addr_v4 = next_ip();
         let addr_v6 = next_ip_v6();

--- a/boringtun/src/device/mod.rs
+++ b/boringtun/src/device/mod.rs
@@ -45,6 +45,7 @@ use allowed_ips::AllowedIps;
 use parking_lot::Mutex;
 use peer::{AllowedIP, Peer};
 use poll::{EventPoll, EventRef, WaitResult};
+use rand::TryRngCore;
 use rand::{rngs::OsRng, RngCore};
 use socket2::{Domain, Protocol, Type};
 use tun::TunSocket;
@@ -868,7 +869,7 @@ impl IndexLfsr {
     fn random_index() -> u32 {
         const LFSR_MAX: u32 = 0xffffff; // 24-bit seed
         loop {
-            let i = OsRng.next_u32() & LFSR_MAX;
+            let i = OsRng.unwrap_err().next_u32() & LFSR_MAX;
             if i > 0 {
                 // LFSR seed must be non-zero
                 return i;

--- a/boringtun/src/ffi/mod.rs
+++ b/boringtun/src/ffi/mod.rs
@@ -13,6 +13,7 @@ use hex::encode as encode_hex;
 use libc::{raise, SIGSEGV};
 use parking_lot::Mutex;
 use rand::rngs::OsRng;
+use rand::TryRngCore;
 use tracing;
 use tracing_subscriber::fmt;
 
@@ -100,7 +101,7 @@ pub struct x25519_key {
 #[no_mangle]
 pub extern "C" fn x25519_secret_key() -> x25519_key {
     x25519_key {
-        key: StaticSecret::random_from_rng(OsRng).to_bytes(),
+        key: StaticSecret::random_from_rng(&mut OsRng.unwrap_mut()).to_bytes(),
     }
 }
 

--- a/boringtun/src/noise/handshake.rs
+++ b/boringtun/src/noise/handshake.rs
@@ -12,7 +12,6 @@ use blake2::digest::{FixedOutput, KeyInit};
 use blake2::{Blake2s256, Blake2sMac, Digest};
 use chacha20poly1305::XChaCha20Poly1305;
 use constant_time_eq::constant_time_eq;
-use rand::rngs::OsRng;
 use ring::aead::{Aad, LessSafeKey, Nonce, UnboundKey, CHACHA20_POLY1305};
 use std::convert::TryInto;
 use std::time::{Duration, Instant, SystemTime};
@@ -755,7 +754,7 @@ impl Handshake {
         let mut hash = INITIAL_CHAIN_HASH;
         hash = b2s_hash(&hash, self.params.peer_static_public.as_bytes());
         // initiator.ephemeral_private = DH_GENERATE()
-        let ephemeral_private = x25519::ReusableSecret::random_from_rng(OsRng);
+        let ephemeral_private = x25519::ReusableSecret::random();
         // msg.message_type = 1
         // msg.reserved_zero = { 0, 0, 0 }
         message_type.copy_from_slice(&super::HANDSHAKE_INIT.to_le_bytes());
@@ -847,7 +846,7 @@ impl Handshake {
         let (encrypted_nothing, _) = rest.split_at_mut(16);
 
         // responder.ephemeral_private = DH_GENERATE()
-        let ephemeral_private = x25519::ReusableSecret::random_from_rng(OsRng);
+        let ephemeral_private = x25519::ReusableSecret::random();
         let local_index = self.next_index.wrapping_increment();
         // msg.message_type = 2
         // msg.reserved_zero = { 0, 0, 0 }

--- a/boringtun/src/noise/mod.rs
+++ b/boringtun/src/noise/mod.rs
@@ -730,19 +730,19 @@ mod tests {
     use std::time::Instant;
 
     use super::*;
-    use rand::{rngs::OsRng, RngCore};
+    use rand::{rngs::OsRng, RngCore, TryRngCore};
     use timers::{KEEPALIVE_TIMEOUT, MAX_JITTER, REJECT_AFTER_TIME, SHOULD_NOT_USE_AFTER_TIME};
     use tracing::{level_filters::LevelFilter, Level};
     use tracing_subscriber::util::SubscriberInitExt;
 
     fn create_two_tuns(now: Instant) -> (Tunn, Tunn) {
-        let my_secret_key = x25519_dalek::StaticSecret::random_from_rng(OsRng);
+        let my_secret_key = x25519_dalek::StaticSecret::random_from_rng(&mut OsRng.unwrap_mut());
         let my_public_key = x25519_dalek::PublicKey::from(&my_secret_key);
-        let my_idx = OsRng.next_u32() >> 8;
+        let my_idx = OsRng.unwrap_err().next_u32() >> 8;
 
-        let their_secret_key = x25519_dalek::StaticSecret::random_from_rng(OsRng);
+        let their_secret_key = x25519_dalek::StaticSecret::random_from_rng(&mut OsRng.unwrap_mut());
         let their_public_key = x25519_dalek::PublicKey::from(&their_secret_key);
-        let their_idx = OsRng.next_u32() >> 8;
+        let their_idx = OsRng.unwrap_err().next_u32() >> 8;
 
         let my_tun = Tunn::new_at(
             my_secret_key,

--- a/boringtun/src/noise/rate_limiter.rs
+++ b/boringtun/src/noise/rate_limiter.rs
@@ -11,6 +11,7 @@ use aead::{AeadInPlace, KeyInit};
 use chacha20poly1305::{Key, XChaCha20Poly1305};
 use constant_time_eq::constant_time_eq;
 use parking_lot::Mutex;
+use rand::TryRngCore;
 use rand::{rngs::OsRng, RngCore};
 
 const COOKIE_REFRESH: u64 = 128; // Use 128 and not 120 so the compiler can optimize out the division
@@ -52,7 +53,7 @@ impl RateLimiter {
     #[deprecated(note = "Prefer `RateLimiter::new_at` to avoid time-impurity")]
     pub fn new(public_key: &crate::x25519::PublicKey, limit: u64) -> Self {
         let mut secret_key = [0u8; 16];
-        OsRng.fill_bytes(&mut secret_key);
+        OsRng.unwrap_err().fill_bytes(&mut secret_key);
         RateLimiter {
             nonce_key: Self::rand_bytes(),
             secret_key,
@@ -68,7 +69,8 @@ impl RateLimiter {
 
     pub fn new_at(public_key: &crate::x25519::PublicKey, limit: u64, now: Instant) -> Self {
         let mut secret_key = [0u8; 16];
-        OsRng.fill_bytes(&mut secret_key);
+        OsRng.unwrap_err().fill_bytes(&mut secret_key);
+
         RateLimiter {
             nonce_key: Self::rand_bytes(),
             secret_key,
@@ -84,7 +86,7 @@ impl RateLimiter {
 
     fn rand_bytes() -> [u8; 32] {
         let mut key = [0u8; 32];
-        OsRng.fill_bytes(&mut key);
+        OsRng.unwrap_err().fill_bytes(&mut key);
         key
     }
 

--- a/boringtun/src/noise/timers.rs
+++ b/boringtun/src/noise/timers.rs
@@ -367,7 +367,7 @@ impl Tunn {
             let jitter = self
                 .timers
                 .jitter_rng
-                .gen_range(Duration::ZERO..=MAX_JITTER);
+                .random_range(Duration::ZERO..=MAX_JITTER);
 
             let existing = self.timers.send_handshake_at.replace(now + jitter);
             debug_assert!(


### PR DESCRIPTION
Unfortunately, both `rand` and `x25519-dalek` are "exposed" dependencies of `boringtun`. In other words, they are part of our public API and thus bumping them by a minor version is a backwards-incompatible Rust API change. The wire format is unaffected.

In order to bump to the latest version of `rand` in Firezone, we need to update `boringtun` to the latest `rand` first.

For our purposes, this is fine because we only directly depend on `boringtun`. Hence, we can adapt our call-sites to these new APIs easily. I don't know how many other users of our fork are out there because if they want to replace their version of `boringtun` deep down in their dependency tree, then going forward, this will no longer work for them.

We've been delaying making any kind of breaking changes to the API for a while even though it would be nice to e.g. improve the errors and remove some of the unused ones.

Once this PR is in, we can do that because the version bump to 0.7 now allows breaking changes.