### PR TITLE
feat: make `KEEPALIVE_TIMEOUT` configurable

### DIFF
--- a/boringtun/src/noise/mod.rs
+++ b/boringtun/src/noise/mod.rs
@@ -317,6 +317,13 @@ impl Tunn {
         self.timers.set_rekey_attempt_time(rekey_attempt_time);
     }
 
+    /// Set the `KEEPALIVE_TIMEOUT`.
+    ///
+    /// Defaults to 10s.
+    pub fn set_keepalive_timeout(&mut self, keepalive_timeout: Duration) {
+        self.timers.set_keepalive_timeout(keepalive_timeout);
+    }
+
     /// Encapsulate a single packet from the tunnel interface.
     /// Returns TunnResult.
     ///

--- a/boringtun/src/noise/timers.rs
+++ b/boringtun/src/noise/timers.rs
@@ -75,6 +75,7 @@ pub struct Timers {
     jitter_rng: StdRng,
 
     rekey_attempt_time: Duration,
+    keepalive_timeout: Duration,
 }
 
 impl Timers {
@@ -94,6 +95,7 @@ impl Timers {
             send_handshake_at: None,
             jitter_rng: StdRng::seed_from_u64(rng_seed),
             rekey_attempt_time: REKEY_ATTEMPT_TIME,
+            keepalive_timeout: KEEPALIVE_TIMEOUT,
         }
     }
 
@@ -117,6 +119,10 @@ impl Timers {
 
     pub(crate) fn set_rekey_attempt_time(&mut self, rekey_attempt_time: Duration) {
         self.rekey_attempt_time = rekey_attempt_time;
+    }
+
+    pub(crate) fn set_keepalive_timeout(&mut self, keepalive_timeout: Duration) {
+        self.keepalive_timeout = keepalive_timeout;
     }
 }
 
@@ -143,7 +149,7 @@ impl Tunn {
                 self.timers.want_passive_keepalive_at = None;
             }
             TimeLastDataPacketReceived => {
-                self.timers.want_passive_keepalive_at = Some(now + KEEPALIVE_TIMEOUT);
+                self.timers.want_passive_keepalive_at = Some(now + self.timers.keepalive_timeout);
             }
             TimeLastDataPacketSent => {
                 match self.timers.want_handshake_at {
@@ -155,7 +161,7 @@ impl Tunn {
                         // We sent a packet and haven't heard back yet.
                         // Start a timer for when we want to make a new handshake.
                         self.timers.want_handshake_at =
-                            Some(now + KEEPALIVE_TIMEOUT + REKEY_TIMEOUT)
+                            Some(now + self.timers.keepalive_timeout + REKEY_TIMEOUT)
                     }
                 }
             }
@@ -318,7 +324,7 @@ impl Tunn {
                 // handshake.
                 if session_established < data_packet_received
                     && now - session_established
-                        >= REJECT_AFTER_TIME - KEEPALIVE_TIMEOUT - REKEY_TIMEOUT
+                        >= REJECT_AFTER_TIME - self.timers.keepalive_timeout - REKEY_TIMEOUT
                 {
                     tracing::debug!(
                         "HANDSHAKE(REJECT_AFTER_TIME - KEEPALIVE_TIMEOUT - REKEY_TIMEOUT (on receive))"


### PR DESCRIPTION
Allows the `KEEPALIVE_TIMEOUT` which by default is set to 10s to be configured at runtime. The `KEEPALIVE_TIMEOUT` is used as part of the WireGuard state machine to decide, how long we wait after an incoming packet has been received to send an empty keepalive packet in absence of an organic reply.

Tweaking this variable is useful if the WireGuard timers are the deciding factors as to whether a connection is healthy.