### PR TITLE
fix: change nonce counter from `AtomicUsize` to `AtomicU64`

### DIFF
--- a/boringtun/src/noise/session.rs
+++ b/boringtun/src/noise/session.rs
@@ -10,7 +10,7 @@ use crate::noise::errors::WireGuardError;
 use parking_lot::Mutex;
 use ring::aead::{Aad, LessSafeKey, Nonce, UnboundKey, CHACHA20_POLY1305};
 use std::{
-    sync::atomic::{AtomicUsize, Ordering},
+    sync::atomic::{AtomicU64, Ordering},
     time::Instant,
 };
 
@@ -20,7 +20,7 @@ pub struct Session {
     sending_index: Index,
     receiver: LessSafeKey,
     sender: LessSafeKey,
-    sending_key_counter: AtomicUsize,
+    sending_key_counter: AtomicU64,
     receiving_key_counter: Mutex<ReceivingKeyCounterValidator>,
 }
 
@@ -185,7 +185,7 @@ impl Session {
                 UnboundKey::new(&CHACHA20_POLY1305, &receiving_key).unwrap(),
             ),
             sender: LessSafeKey::new(UnboundKey::new(&CHACHA20_POLY1305, &sending_key).unwrap()),
-            sending_key_counter: AtomicUsize::new(0),
+            sending_key_counter: AtomicU64::new(0),
             receiving_key_counter: Mutex::new(Default::default()),
         }
     }
@@ -239,7 +239,7 @@ impl Session {
             return Err(WireGuardError::DestinationBufferTooSmall);
         }
 
-        let sending_key_counter = self.sending_key_counter.fetch_add(1, Ordering::Relaxed) as u64;
+        let sending_key_counter = self.sending_key_counter.fetch_add(1, Ordering::Relaxed);
 
         let (message_type, rest) = dst.split_at_mut(4);
         let (receiver_index, rest) = rest.split_at_mut(4);


### PR DESCRIPTION
Change `sending_key_counter` nonce counter type from `AtomicUSize` to `AtomicU64` in session.rs to remove security dependency on value of rekey timer. This removes the risk of a nonce reuse attack on 32-bit platforms if the REKEY_AFTER_TIME = 120 seconds (in timers.rs) value is ever changed to a higher value by a user/developer (e.g., to improve performance on lower powered systems). Behaviour should otherwise be identical.

Related: https://github.com/cloudflare/boringtun/pull/468