### PR TITLE
fix: use `portable-atomic` library to support 32-bit targets

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -138,6 +138,7 @@ dependencies = [
  "libc",
  "nix",
  "parking_lot",
+ "portable-atomic",
  "rand",
  "ring",
  "socket2",
@@ -833,6 +834,12 @@ dependencies = [
  "opaque-debug",
  "universal-hash",
 ]
+
+[[package]]
+name = "portable-atomic"
+version = "1.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
 
 [[package]]
 name = "powerfmt"

--- a/boringtun/Cargo.toml
+++ b/boringtun/Cargo.toml
@@ -29,6 +29,7 @@ base64 = { version = "0.22", optional = true }
 hex = { version = "0.4", optional = true }
 libc = { version = "0.2", optional = true }
 parking_lot = "0.12"
+portable-atomic = { version = "1.13.1", features = ["fallback"] }
 tracing = "0.1.44"
 tracing-subscriber = { version = "0.3", features = ["fmt"], optional = true }
 ip_network = { version = "0.4.1", optional = true }

--- a/boringtun/src/noise/rate_limiter.rs
+++ b/boringtun/src/noise/rate_limiter.rs
@@ -3,7 +3,6 @@ use crate::noise::handshake::{LABEL_COOKIE, LABEL_MAC1};
 use crate::noise::{HandshakeInit, HandshakeResponse, Packet, Tunn, TunnResult, WireGuardError};
 
 use std::net::IpAddr;
-use std::sync::atomic::{AtomicU64, Ordering};
 use std::time::Instant;
 
 use aead::generic_array::GenericArray;
@@ -11,6 +10,7 @@ use aead::{AeadInPlace, KeyInit};
 use chacha20poly1305::{Key, XChaCha20Poly1305};
 use constant_time_eq::constant_time_eq;
 use parking_lot::Mutex;
+use portable_atomic::{AtomicU64, Ordering};
 use rand::{rngs::OsRng, RngCore};
 
 const COOKIE_REFRESH: u64 = 128; // Use 128 and not 120 so the compiler can optimize out the division

--- a/boringtun/src/noise/session.rs
+++ b/boringtun/src/noise/session.rs
@@ -8,11 +8,9 @@ use super::{
 };
 use crate::noise::errors::WireGuardError;
 use parking_lot::Mutex;
+use portable_atomic::{AtomicU64, Ordering};
 use ring::aead::{Aad, LessSafeKey, Nonce, UnboundKey, CHACHA20_POLY1305};
-use std::{
-    sync::atomic::{AtomicU64, Ordering},
-    time::Instant,
-};
+use std::time::Instant;
 
 pub struct Session {
     established_at: Instant,


### PR DESCRIPTION
With #174, we are fixing a potential nonce-reuse vulnerability by enforcing the nonce to be an `AtomicU64`. This however is not available on 32-bit platforms like `arm-linux-androideabi`. To resolve this, switch to the `portable-atomics` crate.