### PR TITLE
feat: use aws-lc-rs instead of ring for ChaCha20-Poly1305

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -96,6 +96,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
+name = "aws-lc-rs"
+version = "1.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ec2f1fc3ec205783a5da9a7e6c1509cc69dedf09a1949e412c1e18469326d00"
+dependencies = [
+ "aws-lc-sys",
+ "untrusted",
+ "zeroize",
+]
+
+[[package]]
+name = "aws-lc-sys"
+version = "0.41.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a2f9779ce85b93ab6170dd940ad0169b5766ff848247aff13bb788b832fe3f4"
+dependencies = [
+ "cc",
+ "cmake",
+ "dunce",
+ "fs_extra",
+]
+
+[[package]]
 name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -130,6 +153,7 @@ name = "boringtun"
 version = "0.7.0"
 dependencies = [
  "aead",
+ "aws-lc-rs",
  "base64",
  "blake2",
  "chacha20poly1305",
@@ -146,7 +170,6 @@ dependencies = [
  "parking_lot",
  "portable-atomic",
  "rand",
- "ring",
  "socket2",
  "thiserror 2.0.18",
  "tracing",
@@ -193,10 +216,13 @@ checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
 name = "cc"
-version = "1.2.14"
+version = "1.2.65"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c3d1b2e905a3a7b00a6141adb0e4c0bb941d11caf55349d863942a1cc44e3c9"
+checksum = "e228eec9be7c17ccb640b59b36a5cd805ea2a564a4c5e162c2f659fea30d3b96"
 dependencies = [
+ "find-msvc-tools",
+ "jobserver",
+ "libc",
  "shlex",
 ]
 
@@ -317,6 +343,15 @@ name = "clap_lex"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
+
+[[package]]
+name = "cmake"
+version = "0.1.58"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0f78a02292a74a88ac736019ab962ece0bc380e3f977bf72e376c5d78ff0678"
+dependencies = [
+ "cc",
+]
 
 [[package]]
 name = "cmov"
@@ -531,6 +566,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "dunce"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
+
+[[package]]
 name = "either"
 version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -558,10 +599,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "64cd1e32ddd350061ae6edb1b082d7c54915b5c672c389143b9a63403a109f24"
 
 [[package]]
+name = "find-msvc-tools"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
+
+[[package]]
 name = "foldhash"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
+
+[[package]]
+name = "fs_extra"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
 
 [[package]]
 name = "generic-array"
@@ -586,13 +639,25 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi 5.3.0",
+ "wasip2",
+]
+
+[[package]]
+name = "getrandom"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
 dependencies = [
  "cfg-if",
  "libc",
- "r-efi",
+ "r-efi 6.0.0",
  "rand_core 0.10.1",
  "wasip2",
  "wasip3",
@@ -751,6 +816,16 @@ name = "jni-sys"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8eaf4bc02d17cbdd7ff4c7438cafcdf7fb9a4613313ad11b4f8fefe7d3fa0130"
+
+[[package]]
+name = "jobserver"
+version = "0.1.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9afb3de4395d6b3e67a780b6de64b51c978ecf11cb9a462c66be7d4ca9039d33"
+dependencies = [
+ "getrandom 0.3.4",
+ "libc",
+]
 
 [[package]]
 name = "js-sys"
@@ -1002,6 +1077,12 @@ dependencies = [
 
 [[package]]
 name = "r-efi"
+version = "5.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
+
+[[package]]
+name = "r-efi"
 version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
@@ -1079,20 +1160,6 @@ name = "regex-syntax"
 version = "0.6.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a3f87b73ce11b1619a3c6332f45341e0047173771e8b8b73f87bfeefb7b56244"
-
-[[package]]
-name = "ring"
-version = "0.17.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
-dependencies = [
- "cc",
- "cfg-if",
- "getrandom 0.2.10",
- "libc",
- "untrusted",
- "windows-sys 0.52.0",
-]
 
 [[package]]
 name = "rustc_version"
@@ -1182,9 +1249,9 @@ dependencies = [
 
 [[package]]
 name = "shlex"
-version = "1.3.0"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
 
 [[package]]
 name = "smallvec"
@@ -1432,9 +1499,9 @@ dependencies = [
 
 [[package]]
 name = "untrusted"
-version = "0.9.0"
+version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
+checksum = "a156c684c91ea7d62626509bce3cb4e1d9ed5c4d978f7b4352658f96a4c26b4a"
 
 [[package]]
 name = "utf8parse"
@@ -1879,6 +1946,6 @@ dependencies = [
 
 [[package]]
 name = "zeroize"
-version = "1.5.6"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20b578acffd8516a6c3f2a1bdefc1ec37e547bb4e0fb8b6b01a4cafc886b4442"
+checksum = "e13c156562582aa81c60cb29407084cdb54c4164760106ab78e6c5b0858cf64e"

--- a/boringtun/Cargo.toml
+++ b/boringtun/Cargo.toml
@@ -38,7 +38,7 @@ tracing = "0.1.44"
 tracing-subscriber = { version = "0.3", features = ["fmt"], optional = true }
 ip_network = { version = "0.4.1", optional = true }
 ip_network_table = { version = "0.2.0", optional = true }
-aws-lc-rs = "1.14"
+aws-lc-rs = { version = "1.14", features = ["prebuilt-nasm"] }
 x25519-dalek = { version = "=3.0.0-rc.0", features = [
     "reusable_secrets",
     "static_secrets",

--- a/boringtun/Cargo.toml
+++ b/boringtun/Cargo.toml
@@ -38,7 +38,7 @@ tracing = "0.1.44"
 tracing-subscriber = { version = "0.3", features = ["fmt"], optional = true }
 ip_network = { version = "0.4.1", optional = true }
 ip_network_table = { version = "0.2.0", optional = true }
-ring = "0.17"
+aws-lc-rs = "1.14"
 x25519-dalek = { version = "=3.0.0-rc.0", features = [
     "reusable_secrets",
     "static_secrets",

--- a/boringtun/benches/crypto_benches/blake2s_benching.rs
+++ b/boringtun/benches/crypto_benches/blake2s_benching.rs
@@ -1,7 +1,7 @@
+use aws_lc_rs::rand::{SecureRandom, SystemRandom};
 use blake2::digest::{FixedOutput, KeyInit};
 use blake2::{Blake2s256, Blake2sMac, Digest};
 use criterion::{BenchmarkId, Criterion, Throughput};
-use ring::rand::{SecureRandom, SystemRandom};
 use typenum::U16;
 
 pub fn bench_blake2s_hash(c: &mut Criterion) {

--- a/boringtun/benches/crypto_benches/chacha20poly1305_benching.rs
+++ b/boringtun/benches/crypto_benches/chacha20poly1305_benching.rs
@@ -1,9 +1,9 @@
 use aead::{AeadInPlace, KeyInit};
+use aws_lc_rs::aead::{Aad, LessSafeKey, Nonce, UnboundKey, CHACHA20_POLY1305};
 use criterion::{BenchmarkId, Criterion, Throughput};
 use rand::Rng;
-use ring::aead::{Aad, LessSafeKey, Nonce, UnboundKey, CHACHA20_POLY1305};
 
-fn chacha20poly1305_ring(key_bytes: &[u8], buf: &mut [u8]) {
+fn chacha20poly1305_aws_lc_rs(key_bytes: &[u8], buf: &mut [u8]) {
     let len = buf.len();
     let n = len - 16;
 
@@ -43,7 +43,7 @@ pub fn bench_chacha20poly1305(c: &mut Criterion) {
         group.throughput(Throughput::Bytes(size as u64));
 
         group.bench_with_input(
-            BenchmarkId::new("chacha20poly1305_ring", size),
+            BenchmarkId::new("chacha20poly1305_aws_lc_rs", size),
             &size,
             |b, i| {
                 let mut key = [0; 32];
@@ -54,7 +54,7 @@ pub fn bench_chacha20poly1305(c: &mut Criterion) {
                 rng.fill_bytes(&mut key);
                 rng.fill_bytes(&mut buf);
 
-                b.iter(|| chacha20poly1305_ring(&key, &mut buf));
+                b.iter(|| chacha20poly1305_aws_lc_rs(&key, &mut buf));
             },
         );
 

--- a/boringtun/benches/crypto_benches/x25519_public_key_benching.rs
+++ b/boringtun/benches/crypto_benches/x25519_public_key_benching.rs
@@ -14,13 +14,15 @@ pub fn bench_x25519_public_key(c: &mut Criterion) {
         });
     });
 
-    group.bench_function("x25519_public_key_ring", |b| {
-        let rng = ring::rand::SystemRandom::new();
+    group.bench_function("x25519_public_key_aws_lc_rs", |b| {
+        let rng = aws_lc_rs::rand::SystemRandom::new();
 
         b.iter(|| {
-            let my_private_key =
-                ring::agreement::EphemeralPrivateKey::generate(&ring::agreement::X25519, &rng)
-                    .unwrap();
+            let my_private_key = aws_lc_rs::agreement::EphemeralPrivateKey::generate(
+                &aws_lc_rs::agreement::X25519,
+                &rng,
+            )
+            .unwrap();
             my_private_key.compute_public_key().unwrap()
         });
     });

--- a/boringtun/benches/crypto_benches/x25519_shared_key_benching.rs
+++ b/boringtun/benches/crypto_benches/x25519_shared_key_benching.rs
@@ -15,28 +15,38 @@ pub fn bench_x25519_shared_key(c: &mut Criterion) {
         );
     });
 
-    group.bench_function("x25519_shared_key_ring", |b| {
-        let rng = ring::rand::SystemRandom::new();
+    group.bench_function("x25519_shared_key_aws_lc_rs", |b| {
+        let rng = aws_lc_rs::rand::SystemRandom::new();
 
         let peer_public_key = {
-            let peer_private_key =
-                ring::agreement::EphemeralPrivateKey::generate(&ring::agreement::X25519, &rng)
-                    .unwrap();
+            let peer_private_key = aws_lc_rs::agreement::EphemeralPrivateKey::generate(
+                &aws_lc_rs::agreement::X25519,
+                &rng,
+            )
+            .unwrap();
             peer_private_key.compute_public_key().unwrap()
         };
-        let peer_public_key_alg = &ring::agreement::X25519;
+        let peer_public_key_alg = &aws_lc_rs::agreement::X25519;
 
         let my_public_key =
-            ring::agreement::UnparsedPublicKey::new(peer_public_key_alg, &peer_public_key);
+            aws_lc_rs::agreement::UnparsedPublicKey::new(peer_public_key_alg, &peer_public_key);
 
         b.iter_batched(
             || {
-                ring::agreement::EphemeralPrivateKey::generate(&ring::agreement::X25519, &rng)
-                    .unwrap()
+                aws_lc_rs::agreement::EphemeralPrivateKey::generate(
+                    &aws_lc_rs::agreement::X25519,
+                    &rng,
+                )
+                .unwrap()
             },
             |my_private_key| {
-                ring::agreement::agree_ephemeral(my_private_key, &my_public_key, |_key_material| ())
-                    .unwrap()
+                aws_lc_rs::agreement::agree_ephemeral(
+                    my_private_key,
+                    my_public_key,
+                    aws_lc_rs::error::Unspecified,
+                    |_key_material| Ok::<(), aws_lc_rs::error::Unspecified>(()),
+                )
+                .unwrap()
             },
             BatchSize::SmallInput,
         );

--- a/boringtun/src/device/integration_tests/mod.rs
+++ b/boringtun/src/device/integration_tests/mod.rs
@@ -7,9 +7,9 @@
 mod tests {
     use crate::device::{DeviceConfig, DeviceHandle};
     use crate::x25519::{PublicKey, StaticSecret};
+    use aws_lc_rs::rand::{SecureRandom, SystemRandom};
     use base64::prelude::*;
     use hex::encode;
-    use ring::rand::{SecureRandom, SystemRandom};
     use std::fmt::Write as _;
     use std::io::{BufRead, BufReader, Read, Write};
     use std::net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr};

--- a/boringtun/src/noise/handshake.rs
+++ b/boringtun/src/noise/handshake.rs
@@ -8,11 +8,11 @@ use crate::noise::errors::WireGuardError;
 use crate::noise::session::Session;
 use crate::x25519;
 use aead::{Aead, KeyInit as _, Payload};
+use aws_lc_rs::aead::{Aad, LessSafeKey, Nonce, UnboundKey, CHACHA20_POLY1305};
 use blake2::digest::{FixedOutput, KeyInit};
 use blake2::{Blake2s256, Blake2sMac, Digest};
 use chacha20poly1305::XChaCha20Poly1305;
 use constant_time_eq::constant_time_eq;
-use ring::aead::{Aad, LessSafeKey, Nonce, UnboundKey, CHACHA20_POLY1305};
 use std::convert::TryInto;
 use std::fmt::{self, Debug};
 use std::time::{Duration, Instant};
@@ -141,7 +141,7 @@ fn aead_chacha20_open_inner(
     nonce: [u8; 12],
     data: &[u8],
     aad: &[u8],
-) -> Result<(), ring::error::Unspecified> {
+) -> Result<(), aws_lc_rs::error::Unspecified> {
     let key = LessSafeKey::new(UnboundKey::new(&CHACHA20_POLY1305, key).unwrap());
 
     let mut inner_buffer = data.to_owned();

--- a/boringtun/src/noise/session.rs
+++ b/boringtun/src/noise/session.rs
@@ -7,9 +7,9 @@ use super::{
     PacketData,
 };
 use crate::noise::errors::WireGuardError;
+use aws_lc_rs::aead::{Aad, LessSafeKey, Nonce, UnboundKey, CHACHA20_POLY1305};
 use parking_lot::Mutex;
 use portable_atomic::{AtomicU64, Ordering};
-use ring::aead::{Aad, LessSafeKey, Nonce, UnboundKey, CHACHA20_POLY1305};
 use std::time::Instant;
 
 pub struct Session {


### PR DESCRIPTION
## What

Swap the `ring` crypto backend for `aws-lc-rs`. `aws-lc-rs` exposes a near drop-in `aead` / `agreement` / `rand` API, so the change is mechanical: the data-plane ChaCha20-Poly1305 (`session.rs`), the handshake AEAD (`handshake.rs`) and the test/bench helpers now import from `aws_lc_rs::*`. `chacha20poly1305` (RustCrypto, used for the `XChaCha20Poly1305` cookie path), `blake2`, `x25519-dalek` etc. are untouched.

## Why

Exploring whether AWS-LC's wider SIMD assembly (the original motivation was AVX-512) buys throughput for WireGuard's ChaCha20-Poly1305.

## Result: no throughput win on ChaCha20-Poly1305

Measured on an AVX-512 capable host (`avx512f/bw/cd/dq/vl`) with warm keys (the real data-plane pattern — one AEAD key per session, reused per packet):

| payload | ring | aws-lc-rs | winner |
|--------:|-----:|----------:|:-------|
| 128 B   | 202 ns | 215 ns | ring +6.1% |
| 192 B   | 227 ns | 239 ns | ring +5.3% |
| 1400 B  | 913 ns | 926 ns | ring +1.4% |
| 8192 B  | 4249 ns | 4264 ns | ring +0.4% |

At the packet sizes WireGuard actually uses the two are at parity, with `ring` marginally ahead everywhere. AWS-LC's headline AVX-512 gains are in AES-GCM (VAES/VPCLMULQDQ), which WireGuard does not use; its ChaCha20-Poly1305 is AVX2-class, same as `ring`.

The tradeoff is real cost: `aws-lc-sys` builds a large C library and needs a C toolchain + CMake (+ NASM on Windows) for every target, versus `ring`'s mostly-prebuilt assembly.

Opened as a **draft** to see how the build fares across CI targets.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Hv1qFbfBQ5oU7RP8Wi2V4N)_