### PR TITLE
ci: report test coverage to Coveralls

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -100,6 +100,24 @@ jobs:
           toolchain: stable
       - run: cargo test -- --ignored
 
+  coverage:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+      - uses: actions-rs/toolchain@16499b5e05bf2e26879000db0c1d13f7e13fa3af # v1.0.7
+        with:
+          toolchain: stable
+      - uses: taiki-e/install-action@50414676f9f5d50a65992c6dd2ed02641263226c # v2.82.10
+        with:
+          tool: cargo-llvm-cov
+      - run: cargo llvm-cov --all-features --lcov --output-path lcov.info
+      - uses: coverallsapp/github-action@648a8eb78e6d50909eff900e4ec85cab4524a45b # v2.3.6
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          file: lcov.info
+          format: lcov
+          fail-on-error: false
+
   semver:
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
Add a coverage job to CI that runs the test suite under `cargo llvm-cov` and uploads the lcov report to Coveralls, mirroring the setup in firezone/firezone (same reporter action and pinned versions). The upload authenticates with the built-in `GITHUB_TOKEN`, so no extra secret is required, and `fail-on-error: false` keeps a flaky upload from failing CI.