### PR TITLE
chore: upgrade x25519-dalek to 3.0.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -476,9 +476,9 @@ dependencies = [
 
 [[package]]
 name = "curve25519-dalek"
-version = "5.0.0-rc.0"
+version = "5.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f359e08ca85e7bd759e1fd933ff2bccd81864c60a8fba0e259c7f822b0924bf"
+checksum = "b5eed333089e2e1c1ac8c6c0398e5e2497b4c9926ca6d0365ed1e099afa5bc23"
 dependencies = [
  "cfg-if",
  "cpufeatures 0.3.0",
@@ -1867,9 +1867,9 @@ dependencies = [
 
 [[package]]
 name = "x25519-dalek"
-version = "3.0.0-rc.0"
+version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f17b575e04fcdb37e5509a85a14ff08116678a1c9724befb8b571db742dbdbb0"
+checksum = "e7e8131a03190127fb2263afc72b322ecadae46b6ff8c6f399ff5d02f5559af6"
 dependencies = [
  "curve25519-dalek",
  "getrandom 0.4.2",

--- a/boringtun/Cargo.toml
+++ b/boringtun/Cargo.toml
@@ -39,7 +39,7 @@ tracing-subscriber = { version = "0.3", features = ["fmt"], optional = true }
 ip_network = { version = "0.4.1", optional = true }
 ip_network_table = { version = "0.2.0", optional = true }
 ring = "0.17"
-x25519-dalek = { version = "=3.0.0-rc.0", features = [
+x25519-dalek = { version = "3.0.0", features = [
     "reusable_secrets",
     "static_secrets",
     "getrandom",


### PR DESCRIPTION
x25519-dalek 3.0.0 and its backing curve25519-dalek 5.0.0 are now stable, so we can replace the RC pin and let the dependency resolve via regular semver again. The rc.0 → stable source diff of both crates is additive (feature-gated `group`/`ff` impls, a `rand_core` re-export); the Montgomery/x25519 code paths are byte-identical.