### PR TITLE
refactor: reset rate-limiter window on use, not on a timer

### DIFF
--- a/boringtun/src/noise/rate_limiter.rs
+++ b/boringtun/src/noise/rate_limiter.rs
@@ -204,6 +204,11 @@ impl RateLimiter {
                 return Err(TunnResult::Err(WireGuardError::InvalidMac));
             }
 
+            // Advance the per-second window before checking it. Resetting it
+            // lazily here, on use, means callers don't need a background timer
+            // ticking once a second just to keep the counter accurate.
+            self.reset_count_at(now);
+
             if self.is_under_load() {
                 let addr = match src_addr {
                     None => return Err(TunnResult::Err(WireGuardError::UnderLoad)),

--- a/boringtun/tests/it/cookies.rs
+++ b/boringtun/tests/it/cookies.rs
@@ -115,3 +115,37 @@ fn rate_limited_tunnel_recovers_once_load_subsides() {
     let response = sim.deliver(B, &init).expect_one_net();
     assert_eq!(classify(&response), Kind::Response);
 }
+
+/// The rate limiter resets its window lazily when a handshake is verified, so
+/// it recovers even if no timers are driven in the meantime. This is what lets
+/// an idle tunnel avoid waking up once a second just to reset the counter.
+#[test]
+fn rate_limiter_resets_without_driving_timers() {
+    let mut sim = Sim::new();
+
+    for _ in 0..10 {
+        let init = sim.force_handshake_initiation(A);
+        sim.deliver(B, &init).expect_one_net();
+        sim.now += std::time::Duration::from_millis(10);
+    }
+
+    let init = sim.force_handshake_initiation(A);
+    let reply = sim.deliver(B, &init).expect_one_net();
+    assert_eq!(
+        classify(&reply),
+        Kind::CookieReply,
+        "11th handshake within a second"
+    );
+
+    // Advance time *without* calling `update_timers_at`, so the only thing that
+    // can clear the window is the lazy reset on the next handshake verification.
+    sim.now += secs(2);
+
+    let init = sim.force_handshake_initiation(A);
+    let response = sim.deliver(B, &init).expect_one_net();
+    assert_eq!(
+        classify(&response),
+        Kind::Response,
+        "window reset on verify, no timer needed"
+    );
+}


### PR DESCRIPTION
The handshake rate-limiter counter is only ever read while verifying a handshake, so resetting it on a background 1-second timer forces callers to wake up once a second for no observable effect. Reset the window lazily on use instead, so an idle tunnel can suspend rather than tick every second just to keep the limiter accurate.

This is behaviourally equivalent to the previous per-second reset. Consumers that drive `reset_count_at` on a timer can drop that timer once they pick this up.