### PR TITLE
fix(noise): expire sessions at the instant we announce

### DIFF
--- a/boringtun/src/noise/session.rs
+++ b/boringtun/src/noise/session.rs
@@ -195,7 +195,7 @@ impl Session {
     }
 
     pub(crate) fn expired_at(&self, time: Instant) -> bool {
-        time > self.established_at + REJECT_AFTER_TIME
+        time >= self.established_at + REJECT_AFTER_TIME
     }
 
     pub(crate) fn should_use_at(&self, time: Instant) -> bool {

--- a/boringtun/tests/it/harness.rs
+++ b/boringtun/tests/it/harness.rs
@@ -45,9 +45,9 @@ pub const COOKIE_REPLY_SIZE: usize = 64;
 /// (implementation-specific; the paper's reference window is 2000 packets).
 pub const REPLAY_WINDOW: u64 = 8192;
 
-/// Minimum step [`Sim::advance`] takes when a timer's deadline lands on the
-/// current instant, so it can nudge past a strictly-after boundary and keep
-/// making progress. It also bounds how late an event may be observed.
+/// Slack the timing assertions allow on either side of a deadline, covering the
+/// few polls a peer may take to act on one (scheduling a handshake at one
+/// instant, sending it at the next).
 pub const TICK: Duration = Duration::from_millis(100);
 
 const BUF: usize = 4096;
@@ -369,24 +369,42 @@ impl Sim {
     /// announce via `next_timer_update` and routing whatever they emit.
     ///
     /// Rather than polling on a fixed interval, we jump straight to the earliest
-    /// instant either peer asked to be called back at. This asserts that
-    /// `next_timer_update` is *complete*: a caller that only ever polls at the
-    /// announced instants observes exactly the same behaviour as one polling
-    /// once a second. The [`TICK`] nudge below is the sole safety net for timers
-    /// whose deadline is reported inclusively but only fires strictly afterwards
-    /// (session expiry), and guarantees forward progress.
+    /// instant either peer asked to be called back at. That asserts two things
+    /// about `next_timer_update` on every test that advances time.
+    ///
+    /// It is *complete*: a caller that only ever polls at the announced instants
+    /// observes exactly the same behaviour as one polling once a second.
+    ///
+    /// Every instant it announces is also *actionable*: polling at one clears
+    /// it. A deadline that survived being polled would be handed straight back
+    /// here and stall the loop, which the assertion below reports.
     pub fn advance(&mut self, duration: Duration) {
         let end = self.now + duration;
+        let mut polls_at_now = 0;
+
         while self.now < end {
             let next = [Peer::A, Peer::B]
                 .into_iter()
                 .filter_map(|peer| self.tunn(peer).next_timer_update())
                 .map(|(at, _reason)| at)
                 .min()
-                // Never move backwards and always make progress, even when a
-                // deadline is reported for the current instant.
-                .map(|at| at.max(self.now + TICK))
+                // Never move backwards: a deadline may have elapsed already.
+                .map(|at| at.max(self.now))
                 .unwrap_or(end);
+
+            // Landing on the current instant is legitimate as long as each poll
+            // drains a timer that is due; the peers hold a handful between them,
+            // so only a long run of them means one never fires at all.
+            if next == self.now {
+                polls_at_now += 1;
+            } else {
+                polls_at_now = 0;
+            }
+            assert!(
+                polls_at_now < 10,
+                "a deadline at {:?} is announced repeatedly but never fires",
+                self.now
+            );
 
             self.now = std::cmp::min(next, end);
             self.poll(Peer::A);

--- a/boringtun/tests/it/sans_io.rs
+++ b/boringtun/tests/it/sans_io.rs
@@ -176,3 +176,36 @@ fn encapsulate_data_at_has_no_side_effects_without_a_session() {
 
     assert!(sim.log.is_empty(), "no handshake may have been initiated");
 }
+
+/// Polling exactly at the announced instant must change something. A deadline
+/// the caller cannot action is a busy-loop: `next_timer_update` keeps handing
+/// back the same instant and `update_timers_at` keeps finding nothing to do.
+///
+/// The session expiry is the case that got this wrong: it was announced at
+/// `established_at + REJECT_AFTER_TIME` while the session was only discarded
+/// strictly *after* that instant, so the one instant the caller was told to
+/// poll was the one instant at which polling could not expire it.
+#[test]
+fn the_announced_session_expiry_is_actionable() {
+    let mut sim = Sim::connected();
+    let mut buf = [0u8; 256];
+
+    // Drain the earlier timers so the session expiry is the next deadline.
+    sim.advance(REJECT_AFTER_TIME - secs(1));
+    let now = sim.now;
+    let tunn = sim.tunn_mut(A);
+    let _ = tunn.update_timers_at(&mut buf, now);
+
+    let Some((wake, "next expired session")) = tunn.next_timer_update() else {
+        panic!("expected the session expiry to be the next deadline");
+    };
+
+    // Poll exactly when told to, then ask again.
+    let _ = tunn.update_timers_at(&mut buf, wake);
+
+    assert_ne!(
+        tunn.next_timer_update().map(|(instant, _)| instant),
+        Some(wake),
+        "polling at the announced instant left the same deadline outstanding"
+    );
+}


### PR DESCRIPTION
`next_timer_update` reports the session expiry at `established_at + REJECT_AFTER_TIME`, but a session was only discarded strictly after that instant. A caller polling exactly when told to therefore could not action that deadline: `update_timers_at` found nothing to do and handed the same instant straight back, so a loop driven purely by `next_timer_update` spun until something else moved the clock. Every other timer in `update_timers_at` already fires on `now >= deadline`; the session expiry is now consistent with them.

The test harness carried a 100ms nudge to step past the boundary, which is what kept this out of the timer tests. It is replaced by an assertion that no deadline survives being polled, so the suite now covers `next_timer_update` being actionable as well as complete.

Related: #213
